### PR TITLE
Release pipeline: tag → changelog → signed APKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+# Triggered when a version tag is pushed (e.g. by `uv run scripts/release.py tag --push`).
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # required to create the GitHub Release
+
+jobs:
+  release:
+    name: Build signed APKs & publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for changelog)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Derive version from tag
+        id: ver
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          echo "name=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog
+        run: uv run scripts/release.py changelog --to "${GITHUB_REF_NAME}" > CHANGELOG_BODY.md
+
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo "$GOOGLE_SERVICES_JSON" | base64 --decode > app/google-services.json
+
+      - name: Decode signing keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
+
+      - name: Build signed release APKs (ABI splits + universal)
+        env:
+          RELEASE_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :app:assembleRelease --no-daemon \
+            -PVERSION_NAME="${{ steps.ver.outputs.name }}" \
+            -PVERSION_CODE="${{ steps.ver.outputs.code }}" \
+            -PGOOGLE_WEB_CLIENT_ID="${{ secrets.GOOGLE_WEB_CLIENT_ID }}"
+
+      - name: Stage APKs with version in filename
+        run: |
+          mkdir -p dist
+          for f in app/build/outputs/apk/release/*.apk; do
+            base=$(basename "$f" .apk)            # e.g. app-arm64-v8a-release
+            abi=${base#app-}; abi=${abi%-release} # e.g. arm64-v8a / universal
+            cp "$f" "dist/sms-forwarder-${{ steps.ver.outputs.name }}-${abi}.apk"
+          done
+          ls -lh dist
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: CHANGELOG_BODY.md
+          files: dist/*.apk
+          fail_on_unmatched_files: true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,9 @@ android {
         applicationId = "com.viswa2k.smsforwarder"
         minSdk = 29
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.1"
+        // Overridable from CI (e.g. -PVERSION_NAME=1.2.0 -PVERSION_CODE=12 derived from the git tag).
+        versionCode = prop("VERSION_CODE").toIntOrNull() ?: 1
+        versionName = prop("VERSION_NAME").ifBlank { "1.1" }
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "GOOGLE_WEB_CLIENT_ID", "\"${prop("GOOGLE_WEB_CLIENT_ID")}\"")
@@ -31,6 +32,30 @@ android {
         // Security settings
         ndk.debugSymbolLevel = "FULL"
         resourceConfigurations.addAll(listOf("en"))
+    }
+
+    // Release signing is driven by environment variables (set by CI from secrets).
+    // When they're absent (e.g. local debug-only builds) the release APK is left unsigned.
+    signingConfigs {
+        create("release") {
+            val storePath = System.getenv("RELEASE_KEYSTORE_PATH")
+            if (storePath != null && file(storePath).exists()) {
+                storeFile = file(storePath)
+                storePassword = System.getenv("RELEASE_STORE_PASSWORD")
+                keyAlias = System.getenv("RELEASE_KEY_ALIAS")
+                keyPassword = System.getenv("RELEASE_KEY_PASSWORD")
+            }
+        }
+    }
+
+    // Per-ABI split APKs (arm64-v8a, armeabi-v7a, x86, x86_64) plus a universal APK.
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+            isUniversalApk = true
+        }
     }
 
     buildTypes {
@@ -42,7 +67,14 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            
+
+            // Sign only when CI provided a keystore; otherwise produce an unsigned release APK.
+            signingConfig = if (System.getenv("RELEASE_KEYSTORE_PATH") != null) {
+                signingConfigs.getByName("release")
+            } else {
+                null
+            }
+
             // Security hardening
             isDebuggable = false
             proguardFile("proguard-rules.pro")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -41,3 +41,18 @@
 # Keep source file names and line numbers
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile
+
+# kotlinx.serialization — keep generated serializers for our @Serializable models
+# (CloudSmsPayload, CloudMessageRepository.FanOut/RecipientCopy used for the offline queue)
+-keepattributes *Annotation*, InnerClasses
+-keepclassmembers @kotlinx.serialization.Serializable class com.viswa2k.smsforwarder.** {
+    *** Companion;
+    *** INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep,includedescriptorclasses class com.viswa2k.smsforwarder.**$$serializer { *; }
+
+# Google Tink (HPKE/AEAD) registers primitives reflectively
+-keep class com.google.crypto.tink.** { *; }
+-keep class com.google.crypto.tink.shaded.protobuf.** { *; }
+-dontwarn com.google.crypto.tink.**

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""Release helper for SMS Forwarder.
+
+Two uses:
+
+  # Cut a release: compute the changelog from the last tag to HEAD, create an
+  # annotated tag whose message IS the changelog, and push it (push triggers
+  # the GitHub Actions release pipeline which builds + publishes signed APKs).
+  uv run scripts/release.py tag --bump patch --push
+  uv run scripts/release.py tag v1.4.0 --push        # explicit version
+
+  # Print the changelog for a tag range (used by CI to build the release notes).
+  uv run scripts/release.py changelog --to v1.4.0
+
+Run from the repository root.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+# Conventional-commit type -> changelog section heading, in display order.
+SECTIONS: list[tuple[str, str]] = [
+    ("feat", "🚀 Features"),
+    ("fix", "🐛 Fixes"),
+    ("perf", "⚡ Performance"),
+    ("refactor", "♻️ Refactoring"),
+    ("docs", "📝 Documentation"),
+    ("test", "✅ Tests"),
+    ("build", "📦 Build"),
+    ("ci", "🤖 CI"),
+    ("chore", "🧹 Chores"),
+]
+_PREFIX = re.compile(r"^(?P<type>\w+)(?:\([^)]*\))?!?:\s*(?P<desc>.+)$")
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(["git", *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"git {' '.join(args)} failed:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def last_tag() -> str | None:
+    """Most recent tag reachable from HEAD, or None if there are no tags yet."""
+    r = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"], capture_output=True, text=True
+    )
+    return r.stdout.strip() or None if r.returncode == 0 else None
+
+
+def prev_tag(ref: str) -> str | None:
+    """The tag immediately preceding `ref`, or None."""
+    r = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0", f"{ref}^"],
+        capture_output=True,
+        text=True,
+    )
+    return r.stdout.strip() or None if r.returncode == 0 else None
+
+
+def commits(rng: str | None) -> list[tuple[str, str]]:
+    """(short_sha, subject) for each commit in `rng` (e.g. 'v1.2.0..HEAD'), or all if None."""
+    args = ["log", "--no-merges", "--pretty=format:%h%x1f%s"]
+    if rng:
+        args.append(rng)
+    out = git(*args)
+    pairs: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if "\x1f" in line:
+            sha, subject = line.split("\x1f", 1)
+            pairs.append((sha, subject))
+    return pairs
+
+
+def build_changelog(prev: str | None, to: str) -> str:
+    rng = f"{prev}..{to}" if prev else None
+    buckets: dict[str, list[str]] = {key: [] for key, _ in SECTIONS}
+    other: list[str] = []
+    for sha, subject in commits(rng):
+        m = _PREFIX.match(subject)
+        if m and m.group("type").lower() in buckets:
+            buckets[m.group("type").lower()].append(f"- {m.group('desc')} ({sha})")
+        else:
+            other.append(f"- {subject} ({sha})")
+
+    lines: list[str] = []
+    for key, heading in SECTIONS:
+        if buckets[key]:
+            lines.append(f"### {heading}")
+            lines.extend(buckets[key])
+            lines.append("")
+    if other:
+        lines.append("### Other")
+        lines.extend(other)
+        lines.append("")
+    if not lines:
+        lines = ["_No changes recorded._", ""]
+
+    header = f"## {to}"
+    if prev:
+        header += f"\n\nChanges since **{prev}**."
+    return header + "\n\n" + "\n".join(lines).rstrip() + "\n"
+
+
+def bump(version: str, part: str) -> str:
+    """Bump a vMAJOR.MINOR.PATCH tag. `version` may be None-ish -> v0.0.0 base."""
+    base = (version or "v0.0.0").lstrip("v")
+    nums = re.findall(r"\d+", base)[:3]
+    major, minor, patch = (int(nums[i]) if i < len(nums) else 0 for i in range(3))
+    if part == "major":
+        major, minor, patch = major + 1, 0, 0
+    elif part == "minor":
+        minor, patch = minor + 1, 0
+    else:
+        patch += 1
+    return f"v{major}.{minor}.{patch}"
+
+
+def cmd_changelog(args: argparse.Namespace) -> None:
+    to = args.to or "HEAD"
+    prev = args.frm or (prev_tag(to) if to != "HEAD" else last_tag())
+    sys.stdout.write(build_changelog(prev, to))
+
+
+def cmd_tag(args: argparse.Namespace) -> None:
+    prev = last_tag()
+    if args.version:
+        new = args.version if args.version.startswith("v") else f"v{args.version}"
+    else:
+        new = bump(prev, args.bump)
+
+    existing = subprocess.run(
+        ["git", "rev-parse", "-q", "--verify", f"refs/tags/{new}"],
+        capture_output=True,
+        text=True,
+    )
+    if existing.returncode == 0:
+        sys.exit(f"Tag {new} already exists.")
+
+    changelog = build_changelog(prev, "HEAD")
+    print(f"Previous tag : {prev or '(none)'}")
+    print(f"New tag      : {new}")
+    print("-" * 60)
+    print(changelog)
+    print("-" * 60)
+
+    if args.dry_run:
+        print("Dry run — no tag created.")
+        return
+
+    git("tag", "-a", new, "-m", changelog)
+    print(f"Created annotated tag {new}.")
+    if args.push:
+        remote = args.remote
+        git("push", remote, new)
+        print(f"Pushed {new} to {remote} — the release workflow will now build and publish APKs.")
+    else:
+        print(f"Not pushed. Run: git push {args.remote} {new}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="SMS Forwarder release helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    t = sub.add_parser("tag", help="create (and optionally push) a release tag")
+    t.add_argument("version", nargs="?", help="explicit version, e.g. v1.4.0 (default: bump last tag)")
+    t.add_argument("--bump", choices=["major", "minor", "patch"], default="patch")
+    t.add_argument("--push", action="store_true", help="push the tag to the remote")
+    t.add_argument("--remote", default="origin")
+    t.add_argument("--dry-run", action="store_true", help="print the changelog without tagging")
+    t.set_defaults(func=cmd_tag)
+
+    c = sub.add_parser("changelog", help="print the changelog for a tag range")
+    c.add_argument("--from", dest="frm", help="start ref (default: previous tag)")
+    c.add_argument("--to", help="end ref (default: HEAD)")
+    c.set_defaults(func=cmd_changelog)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Release pipeline: tag → changelog → signed APKs

Adds a one-command release flow and a CI pipeline that publishes a GitHub Release with signed, per-ABI APKs whenever a `v*` tag is pushed.

### `scripts/release.py` (uv script)
- `uv run scripts/release.py tag --bump patch --push` — finds the last tag, builds a changelog of commits since then (grouped by conventional-commit type), creates an annotated tag whose message *is* the changelog, and pushes it (which triggers the pipeline). Also `tag v1.4.0`, `--dry-run`.
- `uv run scripts/release.py changelog --to <tag>` — prints the changelog for a range (used by CI).
- Pure stdlib, PEP-723 inline metadata; run with uv.

### `.github/workflows/release.yml`
On `push` of a `v*` tag: JDK 17 → generate changelog (via the uv script) → decode `google-services.json` + keystore from secrets → `./gradlew assembleRelease` with version derived from the tag → publish a GitHub Release with the changelog as notes and all APKs attached.

### Build changes (`app/build.gradle.kts`)
- **ABI splits**: `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64` + a universal APK.
- **Env-driven release signing** (CI keystore from secrets); unsigned when absent.
- `versionName`/`versionCode` overridable via `-PVERSION_NAME` / `-PVERSION_CODE` (CI derives from the tag).
- ProGuard keeps for kotlinx-serialization models + Tink (verified `assembleRelease` builds signed APKs under R8).

### Required repo secrets
`GOOGLE_SERVICES_JSON` (base64), `GOOGLE_WEB_CLIENT_ID`, `RELEASE_KEYSTORE_BASE64`, `RELEASE_STORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`.

### Verified
`./gradlew :app:assembleRelease` with the signing env + `-PVERSION_*` produced 5 signed APKs locally; `release.py` tag/changelog tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
