### PR TITLE
Ship a single universal APK (drop redundant ABI splits)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,14 +61,11 @@ jobs:
             -PVERSION_CODE="${{ steps.ver.outputs.code }}" \
             -PGOOGLE_WEB_CLIENT_ID="${{ secrets.GOOGLE_WEB_CLIENT_ID }}"
 
-      - name: Stage APKs with version in filename
+      - name: Stage APK with version in filename
         run: |
           mkdir -p dist
-          for f in app/build/outputs/apk/release/*.apk; do
-            base=$(basename "$f" .apk)            # e.g. app-arm64-v8a-release
-            abi=${base#app-}; abi=${abi%-release} # e.g. arm64-v8a / universal
-            cp "$f" "dist/sms-forwarder-${{ steps.ver.outputs.name }}-${abi}.apk"
-          done
+          cp app/build/outputs/apk/release/app-release.apk \
+            "dist/sms-forwarder-${{ steps.ver.outputs.name }}.apk"
           ls -lh dist
 
       - name: Create GitHub Release

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,15 +48,9 @@ android {
         }
     }
 
-    // Per-ABI split APKs (arm64-v8a, armeabi-v7a, x86, x86_64) plus a universal APK.
-    splits {
-        abi {
-            isEnable = true
-            reset()
-            include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
-            isUniversalApk = true
-        }
-    }
+    // No ABI splits: the only native lib is AndroidX DataStore's ~7 KB shared-counter
+    // .so, so per-ABI APKs differ from the universal by only ~21 KB. A single APK that
+    // works on every device is simpler for sideloading.
 
     buildTypes {
         release {


### PR DESCRIPTION
ABI splits produced 5 near-identical APKs because the app's only native library is AndroidX DataStore's ~7KB shared-counter `.so` — per-ABI APKs differ from the universal by only ~21KB on an ~11MB APK. Removes the `splits` block and publishes one signed `sms-forwarder-<version>.apk`. Verified `assembleRelease` produces a single signed `app-release.apk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)