### PR TITLE
In-app updater: prompt to install newer GitHub Release

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <!-- In-app updater: install the APK downloaded from GitHub Releases -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
 
     <!-- Package visibility for Android 11+ -->
     <queries>

--- a/app/src/main/java/com/viswa2k/smsforwarder/MainActivity.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/MainActivity.kt
@@ -82,6 +82,8 @@ class MainActivity : ComponentActivity() {
                             com.viswa2k.smsforwarder.cloud.ui.CloudNav(cloudVm)
                         }
                     }
+                    // Checks GitHub Releases on launch; prompts to install if a newer APK exists.
+                    com.viswa2k.smsforwarder.cloud.update.UpdateDialogHost()
                 }
             }
         }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateChecker.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateChecker.kt
@@ -1,0 +1,99 @@
+package com.viswa2k.smsforwarder.cloud.update
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.net.HttpURLConnection
+import java.net.URL
+
+/** A newer GitHub release than the running build. */
+data class UpdateInfo(
+    val version: String,      // e.g. "1.2.0" (tag without the leading 'v')
+    val notes: String,        // release body / changelog
+    val apkUrl: String,       // browser_download_url of the .apk asset
+    val apkName: String,      // asset file name, e.g. sms-forwarder-1.2.0.apk
+)
+
+/**
+ * Checks the public GitHub Releases API for a newer version and exposes the APK
+ * to install. Version comparison is pure and unit-tested.
+ */
+object UpdateChecker {
+    private const val LATEST_RELEASE_API =
+        "https://api.github.com/repos/viswanathanTJ/sms-forwarder/releases/latest"
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class GhRelease(
+        @SerialName("tag_name") val tagName: String = "",
+        val body: String? = null,
+        @SerialName("prerelease") val prerelease: Boolean = false,
+        @SerialName("draft") val draft: Boolean = false,
+        val assets: List<GhAsset> = emptyList(),
+    )
+
+    @Serializable
+    private data class GhAsset(
+        val name: String = "",
+        @SerialName("browser_download_url") val browserDownloadUrl: String = "",
+    )
+
+    /** Numeric semver-ish comparison; ignores any non-numeric suffix like "-debug". */
+    fun isNewer(latest: String, current: String): Boolean {
+        val a = numericParts(latest)
+        val b = numericParts(current)
+        val n = maxOf(a.size, b.size)
+        for (i in 0 until n) {
+            val x = a.getOrElse(i) { 0 }
+            val y = b.getOrElse(i) { 0 }
+            if (x != y) return x > y
+        }
+        return false
+    }
+
+    private fun numericParts(version: String): List<Int> =
+        Regex("\\d+").findAll(version.removePrefix("v")).map { it.value.toInt() }.toList()
+
+    /** Returns details of a newer release, or null if up to date / unavailable. */
+    suspend fun checkForUpdate(currentVersion: String): UpdateInfo? = withContext(Dispatchers.IO) {
+        val release = try {
+            fetchLatest()
+        } catch (e: Exception) {
+            Log.w("UpdateChecker", "Update check failed: ${e.message}")
+            return@withContext null
+        }
+        if (release == null || release.draft || release.prerelease) return@withContext null
+
+        val latest = release.tagName.removePrefix("v")
+        if (latest.isBlank() || !isNewer(latest, currentVersion)) return@withContext null
+
+        val apk = release.assets.firstOrNull { it.name.endsWith(".apk", ignoreCase = true) }
+            ?: return@withContext null
+
+        UpdateInfo(
+            version = latest,
+            notes = release.body.orEmpty(),
+            apkUrl = apk.browserDownloadUrl,
+            apkName = apk.name,
+        )
+    }
+
+    private fun fetchLatest(): GhRelease? {
+        val conn = (URL(LATEST_RELEASE_API).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            setRequestProperty("Accept", "application/vnd.github+json")
+            connectTimeout = 10_000
+            readTimeout = 10_000
+        }
+        try {
+            if (conn.responseCode != HttpURLConnection.HTTP_OK) return null
+            val text = conn.inputStream.bufferedReader().use { it.readText() }
+            return json.decodeFromString(GhRelease.serializer(), text)
+        } finally {
+            conn.disconnect()
+        }
+    }
+}

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateDialog.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateDialog.kt
@@ -1,0 +1,60 @@
+package com.viswa2k.smsforwarder.cloud.update
+
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.viswa2k.smsforwarder.BuildConfig
+
+/**
+ * On first composition, checks GitHub Releases for a newer version and, if found,
+ * shows a dismissible dialog offering to download + install it. No-op when the
+ * app is up to date or the check fails (offline, etc.).
+ */
+@Composable
+fun UpdateDialogHost() {
+    val context = LocalContext.current
+    var info by remember { mutableStateOf<UpdateInfo?>(null) }
+    var dismissed by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        info = UpdateChecker.checkForUpdate(BuildConfig.VERSION_NAME)
+    }
+
+    val update = info
+    if (update != null && !dismissed) {
+        AlertDialog(
+            onDismissRequest = { dismissed = true },
+            title = { Text("Update available: ${update.version}") },
+            text = {
+                Text(
+                    text = update.notes.ifBlank { "A new version is available." },
+                    modifier = Modifier
+                        .heightIn(max = 280.dp)
+                        .verticalScroll(rememberScrollState()),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    dismissed = true
+                    UpdateInstaller.startUpdate(context, update)
+                }) { Text("Install") }
+            },
+            dismissButton = {
+                TextButton(onClick = { dismissed = true }) { Text("Later") }
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateDialog.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateDialog.kt
@@ -35,26 +35,33 @@ fun UpdateDialogHost() {
 
     val update = info
     if (update != null && !dismissed) {
-        AlertDialog(
-            onDismissRequest = { dismissed = true },
-            title = { Text("Update available: ${update.version}") },
-            text = {
-                Text(
-                    text = update.notes.ifBlank { "A new version is available." },
-                    modifier = Modifier
-                        .heightIn(max = 280.dp)
-                        .verticalScroll(rememberScrollState()),
-                )
-            },
-            confirmButton = {
-                TextButton(onClick = {
-                    dismissed = true
-                    UpdateInstaller.startUpdate(context, update)
-                }) { Text("Install") }
-            },
-            dismissButton = {
-                TextButton(onClick = { dismissed = true }) { Text("Later") }
-            },
-        )
+        UpdatePromptDialog(update = update, onDismiss = { dismissed = true })
     }
+}
+
+/** The "update available" dialog, reused by the launch check and the manual Settings check. */
+@Composable
+fun UpdatePromptDialog(update: UpdateInfo, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Update available: ${update.version}") },
+        text = {
+            Text(
+                text = update.notes.ifBlank { "A new version is available." },
+                modifier = Modifier
+                    .heightIn(max = 280.dp)
+                    .verticalScroll(rememberScrollState()),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onDismiss()
+                UpdateInstaller.startUpdate(context, update)
+            }) { Text("Install") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Later") }
+        },
+    )
 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateInstaller.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateInstaller.kt
@@ -1,0 +1,93 @@
+package com.viswa2k.smsforwarder.cloud.update
+
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.Settings
+import android.util.Log
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+
+/**
+ * Downloads the release APK with [DownloadManager] and launches the system
+ * package installer when the download completes. The OS handles the
+ * "install unknown apps" consent screen.
+ */
+object UpdateInstaller {
+    private const val APK_MIME = "application/vnd.android.package-archive"
+
+    /** True if the app may install packages (always true below API 26). */
+    fun canInstall(context: Context): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
+            context.packageManager.canRequestPackageInstalls()
+
+    /** Send the user to the "install unknown apps" settings screen for this app. */
+    fun requestInstallPermission(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startActivity(
+                Intent(
+                    Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                    Uri.parse("package:${context.packageName}"),
+                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            )
+        }
+    }
+
+    /**
+     * Enqueue the APK download; on completion, fire the install intent.
+     * If install permission is missing, routes the user to grant it first.
+     */
+    fun startUpdate(context: Context, info: UpdateInfo) {
+        val appContext = context.applicationContext
+        if (!canInstall(appContext)) {
+            Toast.makeText(appContext, "Allow installing apps, then tap Install again", Toast.LENGTH_LONG).show()
+            requestInstallPermission(context)
+            return
+        }
+
+        val dm = appContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        val request = DownloadManager.Request(Uri.parse(info.apkUrl))
+            .setTitle("SMS Forwarder ${info.version}")
+            .setDescription("Downloading update…")
+            .setMimeType(APK_MIME)
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setDestinationInExternalFilesDir(appContext, Environment.DIRECTORY_DOWNLOADS, info.apkName)
+
+        val downloadId = dm.enqueue(request)
+        Toast.makeText(appContext, "Downloading update…", Toast.LENGTH_SHORT).show()
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(c: Context, intent: Intent) {
+                val id = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L)
+                if (id != downloadId) return
+                try {
+                    val uri = dm.getUriForDownloadedFile(downloadId)
+                    if (uri == null) {
+                        Toast.makeText(appContext, "Update download failed", Toast.LENGTH_LONG).show()
+                    } else {
+                        val install = Intent(Intent.ACTION_VIEW).apply {
+                            setDataAndType(uri, APK_MIME)
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        appContext.startActivity(install)
+                    }
+                } catch (e: Exception) {
+                    Log.e("UpdateInstaller", "Install launch failed", e)
+                } finally {
+                    runCatching { appContext.unregisterReceiver(this) }
+                }
+            }
+        }
+        ContextCompat.registerReceiver(
+            appContext,
+            receiver,
+            IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+            ContextCompat.RECEIVER_EXPORTED, // system broadcast; must be exported on API 33+
+        )
+    }
+}

--- a/app/src/main/java/com/viswa2k/smsforwarder/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/ui/screen/SettingsScreen.kt
@@ -16,10 +16,15 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.viswa2k.smsforwarder.BuildConfig
 import com.viswa2k.smsforwarder.SmsForwarderService
 import com.viswa2k.smsforwarder.UserPreferences
+import com.viswa2k.smsforwarder.cloud.update.UpdateChecker
+import com.viswa2k.smsforwarder.cloud.update.UpdateInfo
+import com.viswa2k.smsforwarder.cloud.update.UpdatePromptDialog
 import com.viswa2k.smsforwarder.ui.screen.SettingsViewModel
 import com.viswa2k.smsforwarder.ui.screen.SettingsViewModelFactory
+import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsScreen(userPreferences: UserPreferences, modifier: Modifier = Modifier, onOpenCloud: () -> Unit = {}) {
@@ -40,6 +45,11 @@ fun SettingsScreen(userPreferences: UserPreferences, modifier: Modifier = Modifi
     val telegramUserIds by viewModel.telegramUserIds.collectAsState()
     val isCloudChannelEnabled by viewModel.isCloudChannelEnabled.collectAsState()
     val isReceiveEnabled by viewModel.isReceiveEnabled.collectAsState()
+
+    // Manual "check for updates" state
+    val scope = rememberCoroutineScope()
+    var checkingUpdate by remember { mutableStateOf(false) }
+    var manualUpdate by remember { mutableStateOf<UpdateInfo?>(null) }
 
     // Use LazyColumn for scrolling
     LazyColumn(modifier = modifier.padding(16.dp)) {
@@ -240,6 +250,49 @@ fun SettingsScreen(userPreferences: UserPreferences, modifier: Modifier = Modifi
                         }
                     }
                 }
+
+            // About / Updates Card
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("About", style = MaterialTheme.typography.titleMedium)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Version ${BuildConfig.VERSION_NAME}",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = {
+                            checkingUpdate = true
+                            scope.launch {
+                                val found = UpdateChecker.checkForUpdate(BuildConfig.VERSION_NAME)
+                                checkingUpdate = false
+                                if (found != null) {
+                                    manualUpdate = found
+                                } else {
+                                    Toast.makeText(
+                                        context,
+                                        "You're on the latest version (${BuildConfig.VERSION_NAME})",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                            }
+                        },
+                        enabled = !checkingUpdate,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(if (checkingUpdate) "Checking…" else "Check for updates")
+                    }
+                }
+            }
+
+            manualUpdate?.let { update ->
+                UpdatePromptDialog(update = update, onDismiss = { manualUpdate = null })
+            }
 
             // Save Settings Button
             Row(

--- a/app/src/test/java/com/viswa2k/smsforwarder/cloud/update/UpdateCheckerTest.kt
+++ b/app/src/test/java/com/viswa2k/smsforwarder/cloud/update/UpdateCheckerTest.kt
@@ -1,0 +1,24 @@
+package com.viswa2k.smsforwarder.cloud.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateCheckerTest {
+    @Test fun higherPatchIsNewer() = assertTrue(UpdateChecker.isNewer("1.1.3", "1.1.2"))
+    @Test fun higherMinorIsNewer() = assertTrue(UpdateChecker.isNewer("1.2.0", "1.1.9"))
+    @Test fun higherMajorIsNewer() = assertTrue(UpdateChecker.isNewer("2.0.0", "1.9.9"))
+    @Test fun sameVersionIsNotNewer() = assertFalse(UpdateChecker.isNewer("1.1.2", "1.1.2"))
+    @Test fun olderIsNotNewer() = assertFalse(UpdateChecker.isNewer("1.1.1", "1.1.2"))
+
+    @Test fun ignoresLeadingVAndDebugSuffix() {
+        assertTrue(UpdateChecker.isNewer("v1.1.3", "1.1.2"))
+        assertTrue(UpdateChecker.isNewer("1.1.3", "1.1.2-debug"))
+        assertFalse(UpdateChecker.isNewer("1.1.2", "1.1.2-debug")) // 1.1.2 == 1.1.2
+    }
+
+    @Test fun shorterCurrentTreatedAsZeros() {
+        assertTrue(UpdateChecker.isNewer("1.1.1", "1.1"))   // 1.1.1 > 1.1.0
+        assertFalse(UpdateChecker.isNewer("1.1.0", "1.1"))  // equal
+    }
+}


### PR DESCRIPTION
Adds an in-app update check.

- **`UpdateChecker`** — queries the public `releases/latest` API on launch, compares the tag to `BuildConfig.VERSION_NAME` (pure semver compare, unit-tested), and returns the APK asset if newer. Skips drafts/prereleases.
- **`UpdateInstaller`** — downloads the APK via `DownloadManager` and launches the system package installer on completion; routes to the 'install unknown apps' setting if needed.
- **`UpdateDialogHost`** — dismissible dialog (version + release notes + Install/Later), shown from `MainActivity` on launch.
- Adds `REQUEST_INSTALL_PACKAGES`. Works because the repo is public (no token embedded). Verified: unit test green, debug build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)