### PR TITLE
Request-access flow + robust Google sign-in

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AccessRepository.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AccessRepository.kt
@@ -20,6 +20,21 @@ class AccessRepository(private val db: FirebaseFirestore = FirebaseProvider.db) 
         db.collection("authorized_emails").document(email).delete().await()
     }
 
+    // --- access requests (admin review of self-service signups) ---
+    suspend fun listAccessRequests(): List<AccessRequest> =
+        db.collection("access_requests").get().await().documents
+            .map { AccessRequest(it.id, it.getString("displayName") ?: "") }
+
+    suspend fun approveRequest(email: String, approvedBy: String) {
+        db.collection("authorized_emails").document(email)
+            .set(mapOf("role" to "member", "addedBy" to approvedBy)).await()
+        db.collection("access_requests").document(email).delete().await()
+    }
+
+    suspend fun denyRequest(email: String) {
+        db.collection("access_requests").document(email).delete().await()
+    }
+
     suspend fun listAccessMatrix(): List<AccessGrant> =
         db.collection("access_matrix").get().await().documents
             .map { AccessGrant(it.getString("readerDeviceId") ?: "", it.getString("sourceDeviceId") ?: "") }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AuthRepository.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AuthRepository.kt
@@ -2,6 +2,7 @@ package com.viswa2k.smsforwarder.cloud.data
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -13,6 +14,7 @@ class AuthRepository(
     private val db: FirebaseFirestore = FirebaseProvider.db,
 ) {
     fun currentEmail(): String? = auth.currentUser?.email
+    fun currentDisplayName(): String? = auth.currentUser?.displayName
 
     val authState: Flow<Boolean> = callbackFlow {
         val listener = FirebaseAuth.AuthStateListener { trySend(it.currentUser != null) }
@@ -43,5 +45,24 @@ class AuthRepository(
         val email = currentEmail() ?: return false
         val doc = db.collection("authorized_emails").document(email).get().await()
         return doc.exists() && doc.getString("role") == "admin"
+    }
+
+    /** Submit a self-service access request for the signed-in (but unapproved) account. */
+    suspend fun requestAccess() {
+        val email = currentEmail() ?: return
+        db.collection("access_requests").document(email).set(
+            mapOf(
+                "email" to email,
+                "displayName" to (currentDisplayName() ?: ""),
+                "status" to "pending",
+                "requestedAt" to FieldValue.serverTimestamp(),
+            )
+        ).await()
+    }
+
+    /** True if this account already has a pending access request. */
+    suspend fun hasPendingRequest(): Boolean {
+        val email = currentEmail() ?: return false
+        return db.collection("access_requests").document(email).get().await().exists()
     }
 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/FirestoreModels.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/FirestoreModels.kt
@@ -15,3 +15,4 @@ data class Device(
 data class AuthorizedEmail(val email: String, val role: String)
 data class AccessGrant(val readerDeviceId: String, val sourceDeviceId: String)
 data class Subscription(val readerDeviceId: String, val sourceDeviceId: String, val notify: Boolean)
+data class AccessRequest(val email: String, val displayName: String)

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.viswa2k.smsforwarder.cloud.data.AccessRequest
 import com.viswa2k.smsforwarder.cloud.data.AuthorizedEmail
 import com.viswa2k.smsforwarder.cloud.data.Device
 import kotlinx.coroutines.launch
@@ -23,14 +24,36 @@ fun AdminScreen(vm: CloudViewModel, onBack: () -> Unit) {
     var newEmail by remember { mutableStateOf("") }
     var readerSel by remember { mutableStateOf<String?>(null) }
     var sourceSel by remember { mutableStateOf<String?>(null) }
+    var requests by remember { mutableStateOf<List<AccessRequest>>(emptyList()) }
 
-    suspend fun reload() { emails = access.listAuthorizedEmails(); devices = vm.fleetDevices() }
+    suspend fun reload() {
+        emails = access.listAuthorizedEmails()
+        devices = vm.fleetDevices()
+        requests = access.listAccessRequests()
+    }
     LaunchedEffect(Unit) { reload() }
 
     Scaffold(
         topBar = { TopAppBar(title = { Text("Admin") }, navigationIcon = { TextButton(onClick = onBack) { Text("Back") } }) },
     ) { padding ->
         LazyColumn(Modifier.fillMaxSize().padding(padding).padding(12.dp)) {
+            if (requests.isNotEmpty()) {
+                item { Text("Pending access requests", style = MaterialTheme.typography.titleMedium) }
+                items(requests, key = { it.email }) { req ->
+                    Row(Modifier.fillMaxWidth().padding(vertical = 4.dp), verticalAlignment = Alignment.CenterVertically) {
+                        Column(Modifier.weight(1f)) {
+                            Text(req.email)
+                            if (req.displayName.isNotBlank()) {
+                                Text(req.displayName, style = MaterialTheme.typography.bodySmall)
+                            }
+                        }
+                        TextButton(onClick = { scope.launch { access.approveRequest(req.email, adminEmail); reload() } }) { Text("Approve") }
+                        TextButton(onClick = { scope.launch { access.denyRequest(req.email); reload() } }) { Text("Deny") }
+                    }
+                }
+                item { Spacer(Modifier.height(16.dp)) }
+            }
+
             item { Text("Authorized emails", style = MaterialTheme.typography.titleMedium) }
             item {
                 Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudNav.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudNav.kt
@@ -7,15 +7,28 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 
+/**
+ * Top-level gate: sign-in → (if not allow-listed) request-access → cloud.
+ * The screens are chosen from auth state, so transitions happen automatically
+ * as the user signs in / gets approved.
+ */
 @Composable
 fun CloudNav(vm: CloudViewModel) {
-    val nav = rememberNavController()
     val signedIn by vm.signedIn.collectAsState()
-    val start = if (signedIn) "cloud" else "signin"
-    NavHost(navController = nav, startDestination = start) {
-        composable("signin") { SignInScreen(vm) { nav.navigate("cloud") { popUpTo("signin") { inclusive = true } } } }
-        composable("cloud") { CloudSmsScreen(vm, onOpenWatch = { nav.navigate("watch") }, onOpenAdmin = { nav.navigate("admin") }) }
-        composable("watch") { WatchScreen(vm) { nav.popBackStack() } }
-        composable("admin") { AdminScreen(vm) { nav.popBackStack() } }
+    val authorized by vm.authorized.collectAsState()
+
+    when {
+        !signedIn -> SignInScreen(vm)
+        !authorized -> RequestAccessScreen(vm)
+        else -> {
+            val nav = rememberNavController()
+            NavHost(navController = nav, startDestination = "cloud") {
+                composable("cloud") {
+                    CloudSmsScreen(vm, onOpenWatch = { nav.navigate("watch") }, onOpenAdmin = { nav.navigate("admin") })
+                }
+                composable("watch") { WatchScreen(vm) { nav.popBackStack() } }
+                composable("admin") { AdminScreen(vm) { nav.popBackStack() } }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
@@ -31,6 +31,10 @@ class CloudViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _signedIn = MutableStateFlow(auth.currentEmail() != null)
     val signedIn: StateFlow<Boolean> = _signedIn
+    private val _authorized = MutableStateFlow(false)
+    val authorized: StateFlow<Boolean> = _authorized          // signed in AND on the allow-list
+    private val _pendingRequest = MutableStateFlow(false)
+    val pendingRequest: StateFlow<Boolean> = _pendingRequest  // an access request is awaiting admin approval
     private val _isAdmin = MutableStateFlow(false)
     val isAdmin: StateFlow<Boolean> = _isAdmin
     private val _email = MutableStateFlow(auth.currentEmail())
@@ -41,24 +45,42 @@ class CloudViewModel(app: Application) : AndroidViewModel(app) {
     private var registration: ListenerRegistration? = null
     private var aliasCache: Map<String, String> = emptyMap()
 
-    init { viewModelScope.launch { auth.authState.collect { _signedIn.value = it; _email.value = auth.currentEmail() } } }
+    init {
+        viewModelScope.launch {
+            auth.authState.collect { authed ->
+                _signedIn.value = authed
+                _email.value = auth.currentEmail()
+                if (authed) onAuthenticatedInternal() else resetAuthState()
+            }
+        }
+    }
+
+    private fun resetAuthState() {
+        _authorized.value = false
+        _pendingRequest.value = false
+        _isAdmin.value = false
+    }
 
     fun signInEmail(email: String, password: String, onError: (String) -> Unit) = viewModelScope.launch {
+        // On success the authState collector runs authorization + setup.
         runCatching { auth.signInEmail(email, password) }
-            .onSuccess { onAuthenticatedInternal(onError) }
             .onFailure { onError(it.message ?: "Sign-in failed") }
     }
 
     fun signInGoogle(idToken: String, onError: (String) -> Unit) = viewModelScope.launch {
         runCatching { auth.signInGoogle(idToken) }
-            .onSuccess { onAuthenticatedInternal(onError) }
             .onFailure { onError(it.message ?: "Google sign-in failed") }
     }
 
-    fun onAuthenticated(onError: (String) -> Unit = {}) = viewModelScope.launch { onAuthenticatedInternal(onError) }
-
-    private suspend fun onAuthenticatedInternal(onError: (String) -> Unit) {
-        if (!auth.isAuthorized()) { auth.signOut(); _signedIn.value = false; onError("This email is not authorized."); return }
+    /** Runs whenever a Firebase session becomes active (fresh sign-in or app relaunch). */
+    private suspend fun onAuthenticatedInternal() {
+        val authorized = runCatching { auth.isAuthorized() }.getOrDefault(false)
+        _authorized.value = authorized
+        if (!authorized) {
+            // Not approved: stay signed in so the user can submit an access request.
+            _pendingRequest.value = runCatching { auth.hasPendingRequest() }.getOrDefault(false)
+            return
+        }
         val email = auth.currentEmail() ?: return
         var alias = prefs.deviceAlias.first(); if (alias.isBlank()) alias = android.os.Build.MODEL
         runCatching { deviceRepo.registerThisDevice(email, alias) }
@@ -68,7 +90,17 @@ class CloudViewModel(app: Application) : AndroidViewModel(app) {
         refreshMessages()
     }
 
-    fun signOut() = viewModelScope.launch { runCatching { auth.signOut() }; _signedIn.value = false }
+    fun requestAccess(onDone: () -> Unit = {}) = viewModelScope.launch {
+        runCatching { auth.requestAccess() }
+        _pendingRequest.value = true
+        onDone()
+    }
+
+    fun signOut() = viewModelScope.launch {
+        runCatching { auth.signOut() }
+        _signedIn.value = false
+        resetAuthState()
+    }
 
     fun refreshMessages() = viewModelScope.launch {
         val readerId = prefs.cloudDeviceId.first(); if (readerId.isBlank()) return@launch

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/RequestAccessScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/RequestAccessScreen.kt
@@ -1,0 +1,68 @@
+package com.viswa2k.smsforwarder.cloud.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shown when a Google/email account is authenticated but not on the allow-list.
+ * The user can submit an access request for the super-admin to approve.
+ */
+@Composable
+fun RequestAccessScreen(vm: CloudViewModel) {
+    val email by vm.email.collectAsState()
+    val pending by vm.pendingRequest.collectAsState()
+
+    Column(
+        Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("Account not approved", style = MaterialTheme.typography.headlineSmall, textAlign = TextAlign.Center)
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = email ?: "",
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(12.dp))
+
+        if (pending) {
+            Text(
+                "This email is not available for login yet. Your request has been sent — " +
+                    "an administrator will review it. You'll be able to sign in once approved.",
+                textAlign = TextAlign.Center,
+            )
+        } else {
+            Text(
+                "This email is not available for login. You can request access and an " +
+                    "administrator will review it.",
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(20.dp))
+            Button(onClick = { vm.requestAccess() }, modifier = Modifier.fillMaxWidth()) {
+                Text("Request access")
+            }
+        }
+
+        Spacer(Modifier.height(8.dp))
+        OutlinedButton(onClick = { vm.signOut() }, modifier = Modifier.fillMaxWidth()) {
+            Text("Use a different account")
+        }
+    }
+}

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/SignInScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/SignInScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.NoCredentialException
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.viswa2k.smsforwarder.BuildConfig
 import kotlinx.coroutines.launch
@@ -19,7 +21,7 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 
 @Composable
-fun SignInScreen(vm: CloudViewModel, onSignedIn: () -> Unit) {
+fun SignInScreen(vm: CloudViewModel) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
@@ -50,25 +52,30 @@ fun SignInScreen(vm: CloudViewModel, onSignedIn: () -> Unit) {
                 busy = true; error = null
                 scope.launch {
                     try {
-                        val nonce = sha256(randomNonce())
-                        val option = GetGoogleIdOption.Builder()
-                            .setServerClientId(BuildConfig.GOOGLE_WEB_CLIENT_ID)
-                            .setFilterByAuthorizedAccounts(false)
-                            .setNonce(nonce)
+                        // Explicit "Sign in with Google" button flow: always opens the account
+                        // picker / "add account" UI (unlike GetGoogleIdOption, which throws
+                        // NoCredentialException when nothing is pre-authorized).
+                        val option = GetSignInWithGoogleOption.Builder(BuildConfig.GOOGLE_WEB_CLIENT_ID)
+                            .setNonce(sha256(randomNonce()))
                             .build()
                         val request = GetCredentialRequest.Builder().addCredentialOption(option).build()
                         val result = CredentialManager.create(context).getCredential(context, request)
                         val cred = GoogleIdTokenCredential.createFrom(result.credential.data)
                         vm.signInGoogle(cred.idToken) { busy = false; error = it }
-                    } catch (e: Exception) { busy = false; error = e.message ?: "Google sign-in cancelled" }
+                    } catch (e: GetCredentialCancellationException) {
+                        busy = false // user dismissed the picker — no error
+                    } catch (e: NoCredentialException) {
+                        busy = false
+                        error = "No Google account on this device. Add one in Settings → Accounts, then retry."
+                    } catch (e: Exception) {
+                        busy = false
+                        error = e.message ?: "Google sign-in failed"
+                    }
                 }
             },
             enabled = !busy, modifier = Modifier.fillMaxWidth(),
         ) { Text("Sign in with Google") }
     }
-
-    val signedIn by vm.signedIn.collectAsState()
-    LaunchedEffect(signedIn) { if (signedIn) onSignedIn() }
 }
 
 private fun randomNonce(): String {

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -55,5 +55,15 @@ service cloud.firestore {
       allow delete: if isAdmin();
       allow update: if false;
     }
+
+    // Self-service access requests. A signed-in (but not-yet-approved) user may
+    // create/read ONLY their own pending request; the super-admin reviews them.
+    match /access_requests/{email} {
+      allow create: if authed()
+        && request.auth.token.email == email
+        && request.resource.data.status == 'pending';
+      allow read: if (authed() && request.auth.token.email == email) || isAdmin();
+      allow update, delete: if isAdmin();
+    }
   }
 }


### PR DESCRIPTION
Fixes Google sign-in failing with 'credentials do not exist' and lets unapproved users request access instead of being hard-blocked.

**Sign-in robustness**
- Switched the Google button from `GetGoogleIdOption` (silent bottom-sheet that throws `NoCredentialException`) to `GetSignInWithGoogleOption` — always opens the account picker / add-account. Handles cancel + no-account with friendly messages.

**Request-access model** (admin-approved, per your choice)
- A signed-in account that isn't allow-listed stays authenticated and lands on an 'Account not approved' screen → **Request access** writes a pending `access_requests/{email}` doc.
- Admin screen → new **Pending access requests** section: **Approve** (adds them as a member) / **Deny**.
- New Firestore rule: a signed-in user may create/read only their own pending request; admin reviews.
- `CloudViewModel` now tracks `authorized`/`pendingRequest`; nav gates sign-in → request-access → cloud.

Built + tested on the Mac Studio: assembleDebug + unit tests green.

**Deploy notes (required for Google sign-in to actually work on device):**
1. Register signing SHA-1 `29:C7:83:…:B5:EE` + SHA-256 `9F:23:EC:…:0E:0D` in the Firebase Android app, re-download `google-services.json`, update the `GOOGLE_SERVICES_JSON` secret.
2. Deploy the updated Firestore rules (`firebase deploy --only firestore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)