### PR TITLE
Sign-out, Admin overview/status, smarter update indicator

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/UserPreferences.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/UserPreferences.kt
@@ -28,6 +28,7 @@ class UserPreferences(private val dataStore: DataStore<Preferences>) {
     private val IS_CLOUD_CHANNEL_ENABLED = booleanPreferencesKey("IS_CLOUD_CHANNEL_ENABLED")
     private val IS_RECEIVE_ENABLED = booleanPreferencesKey("IS_RECEIVE_ENABLED")
     private val CLOUD_DEVICE_ID = stringPreferencesKey("CLOUD_DEVICE_ID")
+    private val STORED_UPDATE = stringPreferencesKey("STORED_UPDATE") // last-known newer release (JSON) or ""
 
     // Initialize defaults
     suspend fun initializeDefaults() {
@@ -95,6 +96,7 @@ class UserPreferences(private val dataStore: DataStore<Preferences>) {
     val isCloudChannelEnabled: Flow<Boolean> = dataStore.data.map { it[IS_CLOUD_CHANNEL_ENABLED] ?: false }
     val isReceiveEnabled: Flow<Boolean> = dataStore.data.map { it[IS_RECEIVE_ENABLED] ?: false }
     val cloudDeviceId: Flow<String> = dataStore.data.map { it[CLOUD_DEVICE_ID] ?: "" }
+    val storedUpdate: Flow<String> = dataStore.data.map { it[STORED_UPDATE] ?: "" }
 
     // Save preferences
     suspend fun saveSmsServiceEnabled(enabled: Boolean) {
@@ -178,6 +180,12 @@ class UserPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun saveCloudDeviceId(id: String) {
         dataStore.edit { preferences ->
             preferences[CLOUD_DEVICE_ID] = id
+        }
+    }
+
+    suspend fun saveStoredUpdate(json: String) {
+        dataStore.edit { preferences ->
+            preferences[STORED_UPDATE] = json
         }
     }
 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
@@ -25,8 +25,10 @@ fun AdminScreen(vm: CloudViewModel, onBack: () -> Unit) {
     var readerSel by remember { mutableStateOf<String?>(null) }
     var sourceSel by remember { mutableStateOf<String?>(null) }
     var requests by remember { mutableStateOf<List<AccessRequest>>(emptyList()) }
+    var myDeviceId by remember { mutableStateOf("") }
 
     suspend fun reload() {
+        myDeviceId = vm.myDeviceId()
         emails = access.listAuthorizedEmails()
         devices = vm.fleetDevices()
         requests = access.listAccessRequests()
@@ -37,6 +39,45 @@ fun AdminScreen(vm: CloudViewModel, onBack: () -> Unit) {
         topBar = { TopAppBar(title = { Text("Admin") }, navigationIcon = { TextButton(onClick = onBack) { Text("Back") } }) },
     ) { padding ->
         LazyColumn(Modifier.fillMaxSize().padding(padding).padding(12.dp)) {
+            // Overview
+            item {
+                ElevatedCard(Modifier.fillMaxWidth().padding(bottom = 12.dp)) {
+                    Column(Modifier.padding(16.dp)) {
+                        Text("Cloud SMS", style = MaterialTheme.typography.titleLarge)
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            "Cloud SMS securely syncs incoming text messages between your devices. " +
+                                "Each message is end-to-end encrypted on the sending device and can only be read " +
+                                "by devices you authorize — the server never sees the plaintext. As administrator " +
+                                "you control who can sign in and which device may read which.",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+            // Status
+            item {
+                val thisAlias = devices.firstOrNull { it.id == myDeviceId }?.alias
+                    ?: myDeviceId.take(8).ifBlank { "—" }
+                ElevatedCard(Modifier.fillMaxWidth().padding(bottom = 12.dp)) {
+                    Column(Modifier.padding(16.dp)) {
+                        Text("Status", style = MaterialTheme.typography.titleMedium)
+                        Spacer(Modifier.height(6.dp))
+                        Text("Signed in: $adminEmail  ·  Administrator", style = MaterialTheme.typography.bodyMedium)
+                        Text("This device: $thisAlias", style = MaterialTheme.typography.bodySmall)
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            "Devices: ${devices.size}   ·   Authorized: ${emails.size}   ·   Pending: ${requests.size}",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+            item {
+                Text("Manage", style = MaterialTheme.typography.titleMedium)
+                Spacer(Modifier.height(8.dp))
+            }
+
             if (requests.isNotEmpty()) {
                 item { Text("Pending access requests", style = MaterialTheme.typography.titleMedium) }
                 items(requests, key = { it.email }) { req ->

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudSmsScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudSmsScreen.kt
@@ -25,12 +25,27 @@ fun CloudSmsScreen(vm: CloudViewModel, onOpenWatch: () -> Unit, onOpenAdmin: () 
                 actions = {
                     TextButton(onClick = onOpenWatch) { Text("Watch") }
                     if (isAdmin) TextButton(onClick = onOpenAdmin) { Text("Admin") }
+                    TextButton(onClick = { vm.signOut() }) { Text("Sign out") }
                 },
             )
         },
     ) { padding ->
         if (messages.isEmpty()) {
-            Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) { Text("No messages yet") }
+            Column(
+                Modifier.fillMaxSize().padding(padding).padding(32.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text("No cloud messages yet", style = MaterialTheme.typography.titleMedium)
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Cloud SMS shows incoming texts from your other devices, end-to-end encrypted. " +
+                        "Enable \"Upload to cloud\" on a device to send its SMS here, and use Watch to follow " +
+                        "the devices you're allowed to read.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                )
+            }
         } else {
             LazyColumn(Modifier.fillMaxSize().padding(padding).padding(horizontal = 12.dp)) {
                 items(messages, key = { it.id }) { m ->

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateChecker.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateChecker.kt
@@ -10,6 +10,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 /** A newer GitHub release than the running build. */
+@Serializable
 data class UpdateInfo(
     val version: String,      // e.g. "1.2.0" (tag without the leading 'v')
     val notes: String,        // release body / changelog
@@ -25,6 +26,12 @@ object UpdateChecker {
     private const val LATEST_RELEASE_API =
         "https://api.github.com/repos/viswanathanTJ/sms-forwarder/releases/latest"
     private val json = Json { ignoreUnknownKeys = true }
+
+    /** Serialize a stored update for DataStore, and parse it back (null if blank/invalid). */
+    fun serialize(info: UpdateInfo): String = json.encodeToString(UpdateInfo.serializer(), info)
+    fun deserialize(stored: String): UpdateInfo? =
+        if (stored.isBlank()) null
+        else runCatching { json.decodeFromString(UpdateInfo.serializer(), stored) }.getOrNull()
 
     @Serializable
     private data class GhRelease(

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateDialog.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -16,30 +17,30 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.viswa2k.smsforwarder.BuildConfig
+import com.viswa2k.smsforwarder.UserPreferences
+import com.viswa2k.smsforwarder.dataStore
 
 /**
- * On first composition, checks GitHub Releases for a newer version and, if found,
- * shows a dismissible dialog offering to download + install it. No-op when the
- * app is up to date or the check fails (offline, etc.).
+ * Refreshes the update check on launch and, if a newer version is available
+ * (from the persisted [UpdateManager] state), shows a dismissible prompt.
+ * The persistent indicator lives in Settings → About; this is just the launch nudge.
  */
 @Composable
 fun UpdateDialogHost() {
     val context = LocalContext.current
-    var info by remember { mutableStateOf<UpdateInfo?>(null) }
+    val prefs = remember { UserPreferences(context.dataStore) }
+    val update by UpdateManager.available(prefs).collectAsState(initial = null)
     var dismissed by rememberSaveable { mutableStateOf(false) }
 
-    LaunchedEffect(Unit) {
-        info = UpdateChecker.checkForUpdate(BuildConfig.VERSION_NAME)
-    }
+    LaunchedEffect(Unit) { runCatching { UpdateManager.refresh(prefs) } }
 
-    val update = info
-    if (update != null && !dismissed) {
-        UpdatePromptDialog(update = update, onDismiss = { dismissed = true })
+    val u = update
+    if (u != null && !dismissed) {
+        UpdatePromptDialog(update = u, onDismiss = { dismissed = true })
     }
 }
 
-/** The "update available" dialog, reused by the launch check and the manual Settings check. */
+/** The "update available" dialog, reused by the launch nudge and the Settings indicator. */
 @Composable
 fun UpdatePromptDialog(update: UpdateInfo, onDismiss: () -> Unit) {
     val context = LocalContext.current

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateManager.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/update/UpdateManager.kt
@@ -1,0 +1,33 @@
+package com.viswa2k.smsforwarder.cloud.update
+
+import com.viswa2k.smsforwarder.BuildConfig
+import com.viswa2k.smsforwarder.UserPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Single source of truth for "is an update available?".
+ *
+ * The last check is persisted in DataStore so the indicator survives restarts
+ * without re-checking, and it auto-clears once the installed version catches up
+ * to the stored latest. Callers don't poll: [refresh] runs once on launch /
+ * when a screen opens, and the UI observes [available].
+ */
+object UpdateManager {
+
+    /** Check GitHub and persist: store the newer release, or clear it when up to date. */
+    suspend fun refresh(prefs: UserPreferences) {
+        val info = UpdateChecker.checkForUpdate(BuildConfig.VERSION_NAME)
+        prefs.saveStoredUpdate(if (info != null) UpdateChecker.serialize(info) else "")
+    }
+
+    /**
+     * Emits the stored newer release, or null. Re-filtered against the installed
+     * version so the prompt disappears automatically after the app updates
+     * (installed == latest → no longer "newer" → null).
+     */
+    fun available(prefs: UserPreferences): Flow<UpdateInfo?> = prefs.storedUpdate.map { stored ->
+        UpdateChecker.deserialize(stored)
+            ?.takeIf { UpdateChecker.isNewer(it.version, BuildConfig.VERSION_NAME) }
+    }
+}

--- a/app/src/main/java/com/viswa2k/smsforwarder/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/ui/screen/SettingsScreen.kt
@@ -19,12 +19,10 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.viswa2k.smsforwarder.BuildConfig
 import com.viswa2k.smsforwarder.SmsForwarderService
 import com.viswa2k.smsforwarder.UserPreferences
-import com.viswa2k.smsforwarder.cloud.update.UpdateChecker
-import com.viswa2k.smsforwarder.cloud.update.UpdateInfo
-import com.viswa2k.smsforwarder.cloud.update.UpdatePromptDialog
+import com.viswa2k.smsforwarder.cloud.update.UpdateInstaller
+import com.viswa2k.smsforwarder.cloud.update.UpdateManager
 import com.viswa2k.smsforwarder.ui.screen.SettingsViewModel
 import com.viswa2k.smsforwarder.ui.screen.SettingsViewModelFactory
-import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsScreen(userPreferences: UserPreferences, modifier: Modifier = Modifier, onOpenCloud: () -> Unit = {}) {
@@ -46,10 +44,9 @@ fun SettingsScreen(userPreferences: UserPreferences, modifier: Modifier = Modifi
     val isCloudChannelEnabled by viewModel.isCloudChannelEnabled.collectAsState()
     val isReceiveEnabled by viewModel.isReceiveEnabled.collectAsState()
 
-    // Manual "check for updates" state
-    val scope = rememberCoroutineScope()
-    var checkingUpdate by remember { mutableStateOf(false) }
-    var manualUpdate by remember { mutableStateOf<UpdateInfo?>(null) }
+    // Persistent update state: refreshed once on open, surfaced as an indicator (no manual button).
+    val updateInfo by UpdateManager.available(userPreferences).collectAsState(initial = null)
+    LaunchedEffect(Unit) { runCatching { UpdateManager.refresh(userPreferences) } }
 
     // Use LazyColumn for scrolling
     LazyColumn(modifier = modifier.padding(16.dp)) {
@@ -264,34 +261,27 @@ fun SettingsScreen(userPreferences: UserPreferences, modifier: Modifier = Modifi
                         text = "Version ${BuildConfig.VERSION_NAME}",
                         style = MaterialTheme.typography.bodyMedium
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    OutlinedButton(
-                        onClick = {
-                            checkingUpdate = true
-                            scope.launch {
-                                val found = UpdateChecker.checkForUpdate(BuildConfig.VERSION_NAME)
-                                checkingUpdate = false
-                                if (found != null) {
-                                    manualUpdate = found
-                                } else {
-                                    Toast.makeText(
-                                        context,
-                                        "You're on the latest version (${BuildConfig.VERSION_NAME})",
-                                        Toast.LENGTH_SHORT
-                                    ).show()
-                                }
-                            }
-                        },
-                        enabled = !checkingUpdate,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(if (checkingUpdate) "Checking…" else "Check for updates")
+                    val u = updateInfo
+                    if (u != null) {
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text(
+                            text = "Update available: ${u.version}",
+                            color = MaterialTheme.colorScheme.primary,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(
+                            onClick = { UpdateInstaller.startUpdate(context, u) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) { Text("Update to ${u.version}") }
+                    } else {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "You're on the latest version.",
+                            style = MaterialTheme.typography.bodySmall
+                        )
                     }
                 }
-            }
-
-            manualUpdate?.let { update ->
-                UpdatePromptDialog(update = update, onDismiss = { manualUpdate = null })
             }
 
             // Save Settings Button


### PR DESCRIPTION
Three UX improvements (built green on Studio: assembleDebug + unit tests).

**Logout** — `CloudSmsScreen` top bar gains a **Sign out** action; the empty state now explains what Cloud SMS is.

**Admin page revamp** — adds a clear **Cloud SMS overview** and a **Status** dashboard (signed-in account + role, this device, device/authorized/pending counts) above the management sections.

**Update UX** — last check is persisted (`UpdateManager` + `storedUpdate` pref). The 'Check for updates' button is replaced by a standing **Update available: vX** indicator + Update button; the launch nudge and the indicator share one persisted state, no repeated manual checks, and it **auto-clears once installed == latest**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)