### PR TITLE
Security & robustness hardening batch

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/UserPreferences.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/UserPreferences.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -29,6 +30,7 @@ class UserPreferences(private val dataStore: DataStore<Preferences>) {
     private val IS_RECEIVE_ENABLED = booleanPreferencesKey("IS_RECEIVE_ENABLED")
     private val CLOUD_DEVICE_ID = stringPreferencesKey("CLOUD_DEVICE_ID")
     private val STORED_UPDATE = stringPreferencesKey("STORED_UPDATE") // last-known newer release (JSON) or ""
+    private val LAST_KEY_ROTATION = longPreferencesKey("LAST_KEY_ROTATION") // epoch ms of last identity-key rotation
 
     // Initialize defaults
     suspend fun initializeDefaults() {
@@ -97,6 +99,7 @@ class UserPreferences(private val dataStore: DataStore<Preferences>) {
     val isReceiveEnabled: Flow<Boolean> = dataStore.data.map { it[IS_RECEIVE_ENABLED] ?: false }
     val cloudDeviceId: Flow<String> = dataStore.data.map { it[CLOUD_DEVICE_ID] ?: "" }
     val storedUpdate: Flow<String> = dataStore.data.map { it[STORED_UPDATE] ?: "" }
+    val lastKeyRotation: Flow<Long> = dataStore.data.map { it[LAST_KEY_ROTATION] ?: 0L }
 
     // Save preferences
     suspend fun saveSmsServiceEnabled(enabled: Boolean) {
@@ -186,6 +189,12 @@ class UserPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun saveStoredUpdate(json: String) {
         dataStore.edit { preferences ->
             preferences[STORED_UPDATE] = json
+        }
+    }
+
+    suspend fun saveLastKeyRotation(epochMs: Long) {
+        dataStore.edit { preferences ->
+            preferences[LAST_KEY_ROTATION] = epochMs
         }
     }
 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/crypto/CryptoManager.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/crypto/CryptoManager.kt
@@ -35,14 +35,15 @@ class CryptoManager(context: Context) {
     }
 
     fun newDek(): ByteArray = HpkeCrypto.newDek()
-    fun sealDekTo(recipientPublicKeyset: ByteArray, dek: ByteArray): ByteArray =
-        HpkeCrypto.seal(recipientPublicKeyset, dek, ByteArray(0))
-    fun openWrappedDek(wrappedDek: ByteArray): ByteArray =
-        HpkeCrypto.open(handle(), wrappedDek, ByteArray(0))
-    fun encryptBody(dek: ByteArray, plaintext: ByteArray): HpkeCrypto.EncryptedBody =
-        HpkeCrypto.encryptBody(dek, plaintext)
-    fun decryptBody(dek: ByteArray, ciphertext: ByteArray, nonce: ByteArray): ByteArray =
-        HpkeCrypto.decryptBody(dek, ciphertext, nonce)
+    fun sealDekTo(recipientPublicKeyset: ByteArray, dek: ByteArray, context: ByteArray = ByteArray(0)): ByteArray =
+        HpkeCrypto.seal(recipientPublicKeyset, dek, context)
+    fun openWrappedDek(wrappedDek: ByteArray, context: ByteArray = ByteArray(0)): ByteArray =
+        HpkeCrypto.open(handle(), wrappedDek, context)
+    fun encryptBody(dek: ByteArray, plaintext: ByteArray, aad: ByteArray = ByteArray(0)): HpkeCrypto.EncryptedBody =
+        HpkeCrypto.encryptBody(dek, plaintext, aad)
+    fun decryptBody(dek: ByteArray, ciphertext: ByteArray, nonce: ByteArray, aad: ByteArray = ByteArray(0)): ByteArray =
+        HpkeCrypto.decryptBody(dek, ciphertext, nonce, aad)
+    fun wipe(vararg secrets: ByteArray) = HpkeCrypto.wipe(*secrets)
 
     companion object {
         private const val KEYSET_NAME = "cloud_identity_keyset"

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/crypto/HpkeCrypto.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/crypto/HpkeCrypto.kt
@@ -62,16 +62,23 @@ object HpkeCrypto {
         override fun hashCode(): Int = 31 * ciphertext.contentHashCode() + nonce.contentHashCode()
     }
 
-    fun encryptBody(dek: ByteArray, plaintext: ByteArray): EncryptedBody {
+    fun encryptBody(dek: ByteArray, plaintext: ByteArray, aad: ByteArray = ByteArray(0)): EncryptedBody {
         val iv = ByteArray(GCM_IV_BYTES).also { rng.nextBytes(it) }
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
         cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(dek, "AES"), GCMParameterSpec(GCM_TAG_BITS, iv))
+        if (aad.isNotEmpty()) cipher.updateAAD(aad)
         return EncryptedBody(cipher.doFinal(plaintext), iv)
     }
 
-    fun decryptBody(dek: ByteArray, ciphertext: ByteArray, nonce: ByteArray): ByteArray {
+    fun decryptBody(dek: ByteArray, ciphertext: ByteArray, nonce: ByteArray, aad: ByteArray = ByteArray(0)): ByteArray {
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
         cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(dek, "AES"), GCMParameterSpec(GCM_TAG_BITS, nonce))
+        if (aad.isNotEmpty()) cipher.updateAAD(aad)
         return cipher.doFinal(ciphertext)
+    }
+
+    /** Best-effort wipe of sensitive key bytes from memory. */
+    fun wipe(vararg secrets: ByteArray) {
+        for (s in secrets) s.fill(0)
     }
 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AccessRepository.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AccessRepository.kt
@@ -1,6 +1,7 @@
 package com.viswa2k.smsforwarder.cloud.data
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.tasks.await
 
@@ -50,6 +51,26 @@ class AccessRepository(private val db: FirebaseFirestore = FirebaseProvider.db) 
 
     suspend fun setDeviceRevoked(deviceId: String, revoked: Boolean) {
         db.collection("devices").document(deviceId).set(mapOf("revoked" to revoked), SetOptions.merge()).await()
+    }
+
+    /** Permanently remove a device and ALL of its cloud data (admin-only cleanup). */
+    suspend fun removeDeviceAndData(deviceId: String) {
+        deleteQuery(db.collection("inbox").document(deviceId).collection("messages")) // messages it received
+        deleteQuery(db.collectionGroup("messages").whereEqualTo("sourceDeviceId", deviceId)) // messages it sent
+        for (field in listOf("readerDeviceId", "sourceDeviceId")) {
+            deleteQuery(db.collection("access_matrix").whereEqualTo(field, deviceId))
+            deleteQuery(db.collection("subscriptions").whereEqualTo(field, deviceId))
+        }
+        db.collection("devices").document(deviceId).delete().await()
+    }
+
+    private suspend fun deleteQuery(query: Query) {
+        val docs = query.get().await().documents
+        docs.chunked(450).forEach { chunk ->
+            val batch = db.batch()
+            chunk.forEach { batch.delete(it.reference) }
+            batch.commit().await()
+        }
     }
 
     // --- reader ---

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/CloudMessageRepository.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/CloudMessageRepository.kt
@@ -48,15 +48,19 @@ class CloudMessageRepository(
             .filter { !it.revoked && it.publicKey.isNotBlank() }
             .associate { it.id to it.publicKey }
 
+        // Bind the ciphertext + each wrapped key to this exact (source, message[, recipient])
+        // via AEAD/HPKE associated data, so a message can't be replayed/re-attributed.
+        val messageId = UUID.randomUUID().toString()
         val dek = crypto.newDek()
-        val body = crypto.encryptBody(dek, payload.toJsonBytes())
+        val body = crypto.encryptBody(dek, payload.toJsonBytes(), bodyAad(sourceDeviceId, messageId))
         val copies = recipientIds.mapNotNull { id ->
             keyByDevice[id]?.let { pub ->
-                RecipientCopy(id, enc.encodeToString(crypto.sealDekTo(dec.decode(pub), dek)))
+                RecipientCopy(id, enc.encodeToString(crypto.sealDekTo(dec.decode(pub), dek, dekContext(sourceDeviceId, messageId, id))))
             }
         }
+        crypto.wipe(dek)
         return FanOut(
-            messageId = UUID.randomUUID().toString(),
+            messageId = messageId,
             sourceDeviceId = sourceDeviceId,
             sourceAlias = sourceAlias,
             ciphertextB64 = enc.encodeToString(body.ciphertext),
@@ -64,6 +68,12 @@ class CloudMessageRepository(
             copies = copies,
         )
     }
+
+    private fun bodyAad(source: String, messageId: String): ByteArray =
+        "$source|$messageId".toByteArray(Charsets.UTF_8)
+
+    private fun dekContext(source: String, messageId: String, recipient: String): ByteArray =
+        "$source|$messageId|$recipient".toByteArray(Charsets.UTF_8)
 
     suspend fun pushFanOut(fanOut: FanOut) {
         if (fanOut.copies.isEmpty()) return
@@ -89,21 +99,25 @@ class CloudMessageRepository(
 
     suspend fun listForReader(readerDeviceId: String, aliases: Map<String, String>): List<DecryptedMessage> =
         db.collection("inbox").document(readerDeviceId).collection("messages")
-            .get().await().documents.mapNotNull { decrypt(it, aliases) }
+            .get().await().documents.mapNotNull { decrypt(it, readerDeviceId, aliases) }
             .sortedByDescending { it.originalTimestamp }
 
     suspend fun decryptOne(readerDeviceId: String, messageId: String, aliases: Map<String, String>): DecryptedMessage? {
         val doc = db.collection("inbox").document(readerDeviceId).collection("messages")
             .document(messageId).get().await()
         if (!doc.exists()) return null
-        return decrypt(doc, aliases)
+        return decrypt(doc, readerDeviceId, aliases)
     }
 
-    private fun decrypt(doc: DocumentSnapshot, aliases: Map<String, String>): DecryptedMessage? = try {
-        val dek = crypto.openWrappedDek(dec.decode(doc.getString("wrappedDek")!!))
-        val plain = crypto.decryptBody(dek, dec.decode(doc.getString("ciphertext")!!), dec.decode(doc.getString("nonce")!!))
-        val payload = CloudSmsPayload.fromJsonBytes(plain)
+    private fun decrypt(doc: DocumentSnapshot, readerDeviceId: String, aliases: Map<String, String>): DecryptedMessage? = try {
         val source = doc.getString("sourceDeviceId") ?: ""
+        val messageId = doc.getString("messageId") ?: doc.id
+        val dek = crypto.openWrappedDek(dec.decode(doc.getString("wrappedDek")!!), dekContext(source, messageId, readerDeviceId))
+        val plain = crypto.decryptBody(
+            dek, dec.decode(doc.getString("ciphertext")!!), dec.decode(doc.getString("nonce")!!), bodyAad(source, messageId)
+        )
+        crypto.wipe(dek)
+        val payload = CloudSmsPayload.fromJsonBytes(plain)
         DecryptedMessage(
             id = doc.getString("messageId") ?: doc.id,
             sourceDeviceId = source,

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/CloudUploadQueue.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/CloudUploadQueue.kt
@@ -3,14 +3,27 @@ package com.viswa2k.smsforwarder.cloud.data
 import kotlinx.serialization.json.Json
 import java.io.File
 
-/** File-backed retry queue for encrypted fan-outs. Persists ONLY ciphertext + wrapped DEKs. */
-class CloudUploadQueue(private val dir: File) {
+/**
+ * File-backed retry queue for encrypted fan-outs. Persists ONLY ciphertext + wrapped DEKs.
+ * Bounded to [MAX_ITEMS]: enqueuing past the cap evicts the oldest entry, so a persistent
+ * failure (a "poison" item or a long outage) can never grow the queue without limit.
+ */
+class CloudUploadQueue(private val dir: File, private val maxItems: Int = MAX_ITEMS) {
     init { if (!dir.exists()) dir.mkdirs() }
     private val json = Json { encodeDefaults = true }
 
     fun enqueue(f: CloudMessageRepository.FanOut) {
         File(dir, "${f.messageId}.json").writeText(json.encodeToString(CloudMessageRepository.FanOut.serializer(), f))
+        evictOldestBeyondCap()
     }
+
+    private fun evictOldestBeyondCap() {
+        val files = (dir.listFiles { file -> file.extension == "json" } ?: emptyArray())
+            .sortedBy { it.lastModified() }
+        if (files.size > maxItems) files.take(files.size - maxItems).forEach { it.delete() }
+    }
+
+    companion object { const val MAX_ITEMS = 200 }
 
     fun pending(): List<CloudMessageRepository.FanOut> =
         (dir.listFiles { file -> file.extension == "json" } ?: emptyArray())

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/SmsCloudUploader.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/SmsCloudUploader.kt
@@ -49,9 +49,19 @@ class SmsCloudUploader(context: Context) {
 
     suspend fun flushQueue() {
         if (!prefs.isCloudChannelEnabled.first()) return
+        var consecutiveFailures = 0
         for (f in queue.pending()) {
-            try { messageRepo.pushFanOut(f); queue.remove(f) }
-            catch (e: Exception) { Log.w("SmsCloudUploader", "Retry failed; will try later"); break }
+            try {
+                messageRepo.pushFanOut(f)
+                queue.remove(f)
+                consecutiveFailures = 0
+            } catch (e: Exception) {
+                // Skip a single bad item (don't head-of-line block), but stop after a few
+                // failures in a row — that means we're offline; retry on the next flush.
+                consecutiveFailures++
+                Log.w("SmsCloudUploader", "Retry failed; will try later")
+                if (consecutiveFailures >= 3) break
+            }
         }
     }
 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
@@ -129,6 +129,9 @@ fun AdminScreen(vm: CloudViewModel, onBack: () -> Unit) {
                 Row(Modifier.fillMaxWidth().padding(vertical = 4.dp), verticalAlignment = Alignment.CenterVertically) {
                     Text("${d.alias}${if (d.revoked) " (revoked)" else ""}", Modifier.weight(1f))
                     TextButton(onClick = { scope.launch { access.setDeviceRevoked(d.id, !d.revoked); reload() } }) { Text(if (d.revoked) "Un-revoke" else "Revoke") }
+                    if (d.id != myDeviceId) {
+                        TextButton(onClick = { scope.launch { access.removeDeviceAndData(d.id); reload() } }) { Text("Remove") }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
@@ -82,6 +82,16 @@ class CloudViewModel(app: Application) : AndroidViewModel(app) {
             return
         }
         val email = auth.currentEmail() ?: return
+        // Rotate the identity key every ~30 days (seed the clock on first sign-in); old key
+        // versions are retained in the keyset so historical messages still decrypt.
+        runCatching {
+            val now = System.currentTimeMillis()
+            val last = prefs.lastKeyRotation.first()
+            when {
+                last == 0L -> prefs.saveLastKeyRotation(now)
+                now - last > ROTATION_INTERVAL_MS -> { crypto.rotateIdentityKey(); prefs.saveLastKeyRotation(now) }
+            }
+        }
         var alias = prefs.deviceAlias.first(); if (alias.isBlank()) alias = android.os.Build.MODEL
         runCatching { deviceRepo.registerThisDevice(email, alias) }
         _isAdmin.value = runCatching { auth.isAdmin() }.getOrDefault(false)
@@ -125,4 +135,8 @@ class CloudViewModel(app: Application) : AndroidViewModel(app) {
     fun accessRepository() = accessRepo
 
     override fun onCleared() { stopRealtime() }
+
+    companion object {
+        private const val ROTATION_INTERVAL_MS = 30L * 24 * 60 * 60 * 1000 // ~30 days
+    }
 }

--- a/app/src/test/java/com/viswa2k/smsforwarder/cloud/crypto/HpkeCryptoTest.kt
+++ b/app/src/test/java/com/viswa2k/smsforwarder/cloud/crypto/HpkeCryptoTest.kt
@@ -34,6 +34,21 @@ class HpkeCryptoTest {
     }
 
     @Test
+    fun body_aad_roundTripsAndRejectsMismatch() {
+        val dek = HpkeCrypto.newDek()
+        val plain = "OTP 4471".toByteArray()
+        val aad = "src|msg123".toByteArray()
+        val enc = HpkeCrypto.encryptBody(dek, plain, aad)
+        // Correct AAD decrypts.
+        assertArrayEquals(plain, HpkeCrypto.decryptBody(dek, enc.ciphertext, enc.nonce, aad))
+        // Tampered AAD (e.g. re-attributing the message) must fail the GCM tag check.
+        var failed = false
+        try { HpkeCrypto.decryptBody(dek, enc.ciphertext, enc.nonce, "src|other".toByteArray()) }
+        catch (e: Exception) { failed = true }
+        assertTrue("decrypt must reject a different AAD", failed)
+    }
+
+    @Test
     fun privateKeyset_serializeRoundTrips() {
         val handle = HpkeCrypto.generatePrivateKeyset()
         val restored = HpkeCrypto.deserializePrivateKeyset(HpkeCrypto.serializePrivateKeyset(handle))


### PR DESCRIPTION
Implements the deferred hardening items (built green on Studio: assembleDebug + unit tests incl. a new AAD round-trip/mismatch test).

- **AAD/context-binding** — body AES-GCM AAD = `source|messageId`; per-recipient HPKE contextInfo = `source|messageId|recipient`. Prevents replay/re-attribution/squatting. *Breaking for pre-existing ciphertext; cloud has no real data yet.*
- **DEK zeroing** after encrypt/decrypt.
- **Key rotation** ~every 30 days on launch (old key versions kept so history still decrypts).
- **Offline queue** bounded (size cap + evict oldest) and no head-of-line blocking (stops after 3 consecutive failures = offline).
- **Admin device purge** — Remove a device and delete all its cloud data.

Deferred (noted): uploader-reuse (perf), connectivity-triggered flush, rules-emulator suite, Cloud Function deploy (needs Blaze), web sub-project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)