### PR TITLE
feat(cloud): email/password sign-up + auto access request (Waiting for approval)

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
@@ -67,6 +67,18 @@ class CloudViewModel(app: Application) : AndroidViewModel(app) {
             .onFailure { onError(it.message ?: "Sign-in failed") }
     }
 
+    fun signUpEmail(email: String, password: String, onError: (String) -> Unit) = viewModelScope.launch {
+        // Creating the auth account grants no access on its own — the authorized_emails
+        // allow-list (admin approval) still gates all data. We auto-submit the access
+        // request on first sign-up so the user lands directly on "waiting for approval"
+        // instead of a separate "request access" step.
+        runCatching {
+            auth.signUpEmail(email, password)
+            auth.requestAccess()
+        }.onFailure { onError(it.message ?: "Sign-up failed"); return@launch }
+        _pendingRequest.value = true
+    }
+
     fun signInGoogle(idToken: String, onError: (String) -> Unit) = viewModelScope.launch {
         runCatching { auth.signInGoogle(idToken) }
             .onFailure { onError(it.message ?: "Google sign-in failed") }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/RequestAccessScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/RequestAccessScreen.kt
@@ -33,7 +33,11 @@ fun RequestAccessScreen(vm: CloudViewModel) {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text("Account not approved", style = MaterialTheme.typography.headlineSmall, textAlign = TextAlign.Center)
+        Text(
+            if (pending) "Waiting for approval" else "Account not approved",
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
         Spacer(Modifier.height(12.dp))
         Text(
             text = email ?: "",
@@ -44,8 +48,8 @@ fun RequestAccessScreen(vm: CloudViewModel) {
 
         if (pending) {
             Text(
-                "This email is not available for login yet. Your request has been sent — " +
-                    "an administrator will review it. You'll be able to sign in once approved.",
+                "Your request has been sent. An administrator will review it, and you'll " +
+                    "get access automatically once it's approved.",
                 textAlign = TextAlign.Center,
             )
         } else {

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/SignInScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/SignInScreen.kt
@@ -26,6 +26,7 @@ fun SignInScreen(vm: CloudViewModel) {
     var password by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     var busy by remember { mutableStateOf(false) }
+    var signUpMode by remember { mutableStateOf(false) }
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -33,19 +34,35 @@ fun SignInScreen(vm: CloudViewModel) {
         Modifier.fillMaxSize().padding(24.dp),
         verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text("Cloud SMS Sign-in", style = MaterialTheme.typography.headlineSmall)
+        Text(if (signUpMode) "Create Cloud SMS account" else "Cloud SMS Sign-in", style = MaterialTheme.typography.headlineSmall)
         Spacer(Modifier.height(16.dp))
         OutlinedTextField(email, { email = it }, label = { Text("Email") }, singleLine = true, modifier = Modifier.fillMaxWidth())
         Spacer(Modifier.height(8.dp))
         OutlinedTextField(password, { password = it }, label = { Text("Password") }, singleLine = true,
             visualTransformation = PasswordVisualTransformation(), modifier = Modifier.fillMaxWidth())
+        if (signUpMode) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "After creating your account you'll request access; an admin must approve it before you can read messages.",
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
         error?.let { Spacer(Modifier.height(8.dp)); Text(it, color = MaterialTheme.colorScheme.error) }
         Spacer(Modifier.height(16.dp))
         Button(
-            onClick = { busy = true; error = null; vm.signInEmail(email.trim(), password) { busy = false; error = it } },
-            enabled = !busy && email.isNotBlank() && password.isNotBlank(),
+            onClick = {
+                busy = true; error = null
+                val onErr: (String) -> Unit = { busy = false; error = it }
+                if (signUpMode) vm.signUpEmail(email.trim(), password, onErr)
+                else vm.signInEmail(email.trim(), password, onErr)
+            },
+            enabled = !busy && email.isNotBlank() && password.length >= 6,
             modifier = Modifier.fillMaxWidth(),
-        ) { Text("Sign in") }
+        ) { Text(if (signUpMode) "Create account" else "Sign in") }
+        Spacer(Modifier.height(4.dp))
+        TextButton(onClick = { error = null; signUpMode = !signUpMode }, enabled = !busy) {
+            Text(if (signUpMode) "Have an account? Sign in" else "New here? Create an account")
+        }
         Spacer(Modifier.height(8.dp))
         OutlinedButton(
             onClick = {


### PR DESCRIPTION
Adds a **Create account** mode to Cloud SMS sign-in (wired to existing `signUpEmail`). On first sign-up the access request is auto-submitted, landing the user directly on a **Waiting for approval** screen. RequestAccessScreen heading/wording updated.

Safe: creating an auth account grants no access — the `authorized_emails` allow-list + admin approval still gate all data.

## Validation (Genymotion AVD, on-device)
- 'New here? Create an account' toggles to Create mode (header/button/help text update).
- Creating a fresh account auto-submits the request and shows **Waiting for approval** with the new message. Verified visually.
- Confirmed `viswanathantj@gmail.com` already exists as a **Google-provider** account (no password) — hence the original email/password failure; password sign-up correctly reports 'email already in use'.
- Build + unit tests green on Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)