### PR TITLE
feat(cloud): password set/reset + clearer Admin device list

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AuthRepository.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.viswa2k.smsforwarder.cloud.data
 
+import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.firestore.FieldValue
@@ -30,11 +31,39 @@ class AuthRepository(
         auth.createUserWithEmailAndPassword(email, password).await()
     }
 
+    /**
+     * Sends a password-reset email. For an account that only has the Google provider this
+     * lets the user set a password, which adds the email/password credential — after that
+     * they can sign in with email + password too (useful where Google sign-in isn't available).
+     */
+    suspend fun sendPasswordReset(email: String) {
+        auth.sendPasswordResetEmail(email).await()
+    }
+
     suspend fun signInGoogle(idToken: String) {
         auth.signInWithCredential(GoogleAuthProvider.getCredential(idToken, null)).await()
     }
 
     suspend fun signOut() = auth.signOut()
+
+    /** True if the signed-in account already has an email/password credential. */
+    fun hasPasswordProvider(): Boolean =
+        auth.currentUser?.providerData?.any { it.providerId == EmailAuthProvider.PROVIDER_ID } ?: false
+
+    /**
+     * Sets (or changes) the password for the signed-in account. For a Google-only account
+     * this links an email/password credential so the user can also sign in with email +
+     * password; if a password already exists it is updated. May require a recent sign-in.
+     */
+    suspend fun setPassword(newPassword: String) {
+        val user = auth.currentUser ?: throw IllegalStateException("Not signed in")
+        if (hasPasswordProvider()) {
+            user.updatePassword(newPassword).await()
+        } else {
+            val email = user.email ?: throw IllegalStateException("Account has no email")
+            user.linkWithCredential(EmailAuthProvider.getCredential(email, newPassword)).await()
+        }
+    }
 
     suspend fun isAuthorized(): Boolean {
         val email = currentEmail() ?: return false

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
@@ -13,6 +13,10 @@ import com.viswa2k.smsforwarder.cloud.data.AuthorizedEmail
 import com.viswa2k.smsforwarder.cloud.data.Device
 import kotlinx.coroutines.launch
 
+/** Disambiguates same-named devices with a short id, and tags the current device. */
+private fun chipLabel(d: Device, myDeviceId: String): String =
+    d.alias.ifBlank { "(unnamed)" } + " ·" + d.id.take(4) + if (d.id == myDeviceId) " ★" else ""
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdminScreen(vm: CloudViewModel, onBack: () -> Unit) {
@@ -113,10 +117,10 @@ fun AdminScreen(vm: CloudViewModel, onBack: () -> Unit) {
             item {
                 Column {
                     Text("Reader device:")
-                    devices.forEach { d -> FilterChip(selected = readerSel == d.id, onClick = { readerSel = d.id }, label = { Text(d.alias) }) }
+                    devices.forEach { d -> FilterChip(selected = readerSel == d.id, onClick = { readerSel = d.id }, label = { Text(chipLabel(d, myDeviceId)) }) }
                     Spacer(Modifier.height(8.dp))
                     Text("Source device:")
-                    devices.forEach { d -> FilterChip(selected = sourceSel == d.id, onClick = { sourceSel = d.id }, label = { Text(d.alias) }) }
+                    devices.forEach { d -> FilterChip(selected = sourceSel == d.id, onClick = { sourceSel = d.id }, label = { Text(chipLabel(d, myDeviceId)) }) }
                     Button(
                         enabled = readerSel != null && sourceSel != null && readerSel != sourceSel,
                         onClick = { scope.launch { access.grantAccess(readerSel!!, sourceSel!!, adminEmail) } },
@@ -124,12 +128,29 @@ fun AdminScreen(vm: CloudViewModel, onBack: () -> Unit) {
                 }
             }
 
-            item { Spacer(Modifier.height(16.dp)); Text("Devices", style = MaterialTheme.typography.titleMedium) }
+            item {
+                Spacer(Modifier.height(16.dp)); Text("Devices", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "Each install is a separate device. Same name with a different id = a different/old install — remove stale ones.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
             items(devices, key = { it.id }) { d ->
+                val isThis = d.id == myDeviceId
                 Row(Modifier.fillMaxWidth().padding(vertical = 4.dp), verticalAlignment = Alignment.CenterVertically) {
-                    Text("${d.alias}${if (d.revoked) " (revoked)" else ""}", Modifier.weight(1f))
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            buildString {
+                                append(d.alias.ifBlank { "(unnamed)" })
+                                if (isThis) append("  •  This device")
+                                if (d.revoked) append("  •  revoked")
+                            },
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Text("id ${d.id.take(8)}  ·  ${d.ownerEmail}", style = MaterialTheme.typography.bodySmall)
+                    }
                     TextButton(onClick = { scope.launch { access.setDeviceRevoked(d.id, !d.revoked); reload() } }) { Text(if (d.revoked) "Un-revoke" else "Revoke") }
-                    if (d.id != myDeviceId) {
+                    if (!isThis) {
                         TextButton(onClick = { scope.launch { access.removeDeviceAndData(d.id); reload() } }) { Text("Remove") }
                     }
                 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudSmsScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudSmsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -14,9 +15,15 @@ import androidx.compose.ui.unit.dp
 fun CloudSmsScreen(vm: CloudViewModel, onOpenWatch: () -> Unit, onOpenAdmin: () -> Unit) {
     val messages by vm.messages.collectAsState()
     val isAdmin by vm.isAdmin.collectAsState()
+    var menuOpen by remember { mutableStateOf(false) }
+    var showPasswordDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) { vm.refreshMessages(); vm.startRealtime() }
     DisposableEffect(Unit) { onDispose { vm.stopRealtime() } }
+
+    if (showPasswordDialog) {
+        SetPasswordDialog(vm) { showPasswordDialog = false }
+    }
 
     Scaffold(
         topBar = {
@@ -25,7 +32,17 @@ fun CloudSmsScreen(vm: CloudViewModel, onOpenWatch: () -> Unit, onOpenAdmin: () 
                 actions = {
                     TextButton(onClick = onOpenWatch) { Text("Watch") }
                     if (isAdmin) TextButton(onClick = onOpenAdmin) { Text("Admin") }
-                    TextButton(onClick = { vm.signOut() }) { Text("Sign out") }
+                    TextButton(onClick = { menuOpen = true }) { Text("More") }
+                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                        DropdownMenuItem(
+                            text = { Text(if (vm.hasPasswordProvider()) "Change password" else "Set password") },
+                            onClick = { menuOpen = false; showPasswordDialog = true },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Sign out") },
+                            onClick = { menuOpen = false; vm.signOut() },
+                        )
+                    }
                 },
             )
         },
@@ -64,4 +81,43 @@ fun CloudSmsScreen(vm: CloudViewModel, onOpenWatch: () -> Unit, onOpenAdmin: () 
             }
         }
     }
+}
+
+@Composable
+private fun SetPasswordDialog(vm: CloudViewModel, onDismiss: () -> Unit) {
+    var pw1 by remember { mutableStateOf("") }
+    var pw2 by remember { mutableStateOf("") }
+    var busy by remember { mutableStateOf(false) }
+    var msg by remember { mutableStateOf<String?>(null) }
+    var done by remember { mutableStateOf(false) }
+    val email = vm.email.collectAsState().value ?: ""
+    val mismatch = pw2.isNotEmpty() && pw1 != pw2
+
+    AlertDialog(
+        onDismissRequest = { if (!busy) onDismiss() },
+        title = { Text(if (vm.hasPasswordProvider()) "Change password" else "Set password") },
+        text = {
+            Column {
+                Text("For $email", style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(pw1, { pw1 = it }, label = { Text("New password (6+)") }, singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(), modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(pw2, { pw2 = it }, label = { Text("Confirm password") }, singleLine = true,
+                    isError = mismatch, visualTransformation = PasswordVisualTransformation(), modifier = Modifier.fillMaxWidth())
+                msg?.let { Spacer(Modifier.height(8.dp)); Text(it, color = if (done) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error) }
+            }
+        },
+        confirmButton = {
+            if (done) {
+                TextButton(onClick = onDismiss) { Text("Done") }
+            } else {
+                TextButton(
+                    enabled = !busy && pw1.length >= 6 && pw1 == pw2,
+                    onClick = { busy = true; msg = null; vm.setPassword(pw1) { ok, m -> busy = false; msg = m; done = ok } },
+                ) { Text("Save") }
+            }
+        },
+        dismissButton = { if (!done) TextButton(onClick = onDismiss, enabled = !busy) { Text("Cancel") } },
+    )
 }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
@@ -79,6 +79,20 @@ class CloudViewModel(app: Application) : AndroidViewModel(app) {
         _pendingRequest.value = true
     }
 
+    fun hasPasswordProvider(): Boolean = auth.hasPasswordProvider()
+
+    fun setPassword(newPassword: String, onResult: (Boolean, String) -> Unit) = viewModelScope.launch {
+        runCatching { auth.setPassword(newPassword) }
+            .onSuccess { onResult(true, "Password set. You can now sign in with your email and this password.") }
+            .onFailure { onResult(false, it.message ?: "Could not set password") }
+    }
+
+    fun sendPasswordReset(email: String, onResult: (Boolean, String) -> Unit) = viewModelScope.launch {
+        runCatching { auth.sendPasswordReset(email) }
+            .onSuccess { onResult(true, "Password-reset email sent to $email. Open it to set a password, then sign in.") }
+            .onFailure { onResult(false, it.message ?: "Could not send reset email") }
+    }
+
     fun signInGoogle(idToken: String, onError: (String) -> Unit) = viewModelScope.launch {
         runCatching { auth.signInGoogle(idToken) }
             .onFailure { onError(it.message ?: "Google sign-in failed") }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/SignInScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/SignInScreen.kt
@@ -25,6 +25,7 @@ fun SignInScreen(vm: CloudViewModel) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
+    var info by remember { mutableStateOf<String?>(null) }
     var busy by remember { mutableStateOf(false) }
     var signUpMode by remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -48,10 +49,11 @@ fun SignInScreen(vm: CloudViewModel) {
             )
         }
         error?.let { Spacer(Modifier.height(8.dp)); Text(it, color = MaterialTheme.colorScheme.error) }
+        info?.let { Spacer(Modifier.height(8.dp)); Text(it, color = MaterialTheme.colorScheme.primary) }
         Spacer(Modifier.height(16.dp))
         Button(
             onClick = {
-                busy = true; error = null
+                busy = true; error = null; info = null
                 val onErr: (String) -> Unit = { busy = false; error = it }
                 if (signUpMode) vm.signUpEmail(email.trim(), password, onErr)
                 else vm.signInEmail(email.trim(), password, onErr)
@@ -60,8 +62,18 @@ fun SignInScreen(vm: CloudViewModel) {
             modifier = Modifier.fillMaxWidth(),
         ) { Text(if (signUpMode) "Create account" else "Sign in") }
         Spacer(Modifier.height(4.dp))
-        TextButton(onClick = { error = null; signUpMode = !signUpMode }, enabled = !busy) {
+        TextButton(onClick = { error = null; info = null; signUpMode = !signUpMode }, enabled = !busy) {
             Text(if (signUpMode) "Have an account? Sign in" else "New here? Create an account")
+        }
+        if (!signUpMode) {
+            TextButton(
+                onClick = {
+                    error = null; info = null
+                    if (email.isBlank()) { error = "Enter your email first, then tap Forgot password." }
+                    else { busy = true; vm.sendPasswordReset(email.trim()) { ok, msg -> busy = false; if (ok) info = msg else error = msg } }
+                },
+                enabled = !busy,
+            ) { Text("Forgot password? / Set a password") }
         }
         Spacer(Modifier.height(8.dp))
         OutlinedButton(


### PR DESCRIPTION
## What
- **Forgot/Set password (sign-in screen):** sends a reset email; for a Google-only account this lets the user set a password and sign in with email/password afterwards.
- **In-app Set/Change password:** Cloud SMS overflow menu → links an email/password credential to a Google account (or updates an existing password) via `linkWithCredential`/`updatePassword`.
- **Admin device list clarity:** tags **This device**, shows short device id + owner email to disambiguate same-named installs (each install is a distinct device doc), and the grant-access chips are disambiguated too.

## Validation
- Build + unit tests green on Studio.
- On-device (AVD): forgot-password flow verified end-to-end ('Password-reset email sent to …'); app launches clean, no crash.
- Admin page + in-app Set-password dialog are reachable only with an approved/admin session (not possible on this emulator: Google sign-in needs Play Services, approval needs an existing admin) — verified by build + review; to be confirmed live on an approved account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)