### PR TITLE
docs: fix wiki version label to v1.1.10

### DIFF
--- a/docs/wiki.html
+++ b/docs/wiki.html
@@ -118,7 +118,7 @@
   <h2>Changelog</h2>
   <p class="muted">What each version does and what changed — newest first.</p>
   <div class="card">
-    <h3>v1.2.0 <span class="muted">— current</span></h3>
+    <h3>v1.1.10 <span class="muted">— current</span></h3>
     <p><b>What's new:</b> A <b>modern visual refresh</b> across the whole app — a new indigo/teal colour scheme (light &amp; dark), cleaner typography, softer rounded cards, and edge‑to‑edge styling (the app previously used the plain default theme). <b>Bug fix:</b> approving an access request could crash the app — fixed (the admin list now uses unique row keys). The Admin screen is also more resilient: a network/permission error shows a message instead of crashing, and the device list tags <b>“This device”</b> and shows a short id/owner so identically‑named installs are easy to tell apart.</p>
   </div>
   <div class="card">


### PR DESCRIPTION
Auto-bump produced v1.1.10; relabel changelog to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)