### PR TITLE
fix(settings): Cloud upload counts as a forwarding channel

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/ui/screen/SettingsScreen.kt
@@ -293,9 +293,9 @@ fun SettingsScreen(userPreferences: UserPreferences, modifier: Modifier = Modifi
                     onClick = {
                         val validationErrors = mutableListOf<String>()
 
-                        // Validation for smsForwardServiceEnabled
-                        if (smsForwardServiceEnabled && !isBySmsEnabled && !isByTelegramEnabled) {
-                            validationErrors.add("Either 'Forward as SMS' or 'Send in Telegram' must be enabled.")
+                        // At least one delivery channel must be on: SMS, Telegram, or Cloud upload.
+                        if (smsForwardServiceEnabled && !isBySmsEnabled && !isByTelegramEnabled && !isCloudChannelEnabled) {
+                            validationErrors.add("Enable at least one of 'Forward as SMS', 'Send in Telegram', or 'Upload to cloud'.")
                         }
 
                         // Validation for isBySmsEnabled


### PR DESCRIPTION
Saving Settings with the service enabled but only **Upload to cloud** on used to error 'Either Forward as SMS or Send in Telegram must be enabled'. Cloud upload now satisfies the 'at least one channel' rule.

Verified on-device against the **real backend** (signed in as admin): cloud-only now saves with no error; the guard still fires when nothing is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)