### PR TITLE
feat(cloud): local notifications for new cloud messages (Option 1, no FCM)

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/MainActivity.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/MainActivity.kt
@@ -174,12 +174,15 @@ class MainActivity : ComponentActivity() {
 
     private suspend fun checkAndStartService() {
         val smsForwardServiceEnabled = userPreferences.isSmsForwarderService.first()
+        // Cloud-receive users (who don't forward SMS) still need the service alive so it can
+        // post local notifications for new cloud messages.
+        val receiveEnabled = userPreferences.isReceiveEnabled.first()
 
         val serviceIntent = Intent(this, SmsForwarderService::class.java).apply {
             putExtra("SMS_FORWARD_SERVICE_ENABLED", smsForwardServiceEnabled)
         }
 
-        if (smsForwardServiceEnabled) {
+        if (smsForwardServiceEnabled || receiveEnabled) {
             ContextCompat.startForegroundService(this, serviceIntent) // Start the service
         } else {
             this.stopService(serviceIntent) // Stop the service

--- a/app/src/main/java/com/viswa2k/smsforwarder/SMSForwarderService.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/SMSForwarderService.kt
@@ -20,11 +20,13 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import com.viswa2k.smsforwarder.cloud.data.CloudInboxNotifier
 import com.viswa2k.smsforwarder.cloud.data.SmsCloudUploader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class SmsForwarderService : Service() {
@@ -35,6 +37,7 @@ class SmsForwarderService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var connectivityManager: ConnectivityManager? = null
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    private var inboxNotifier: CloudInboxNotifier? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -44,6 +47,9 @@ class SmsForwarderService : Service() {
         // Flush any queued cloud uploads as soon as the network comes back, instead of
         // waiting for the next app launch / sign-in.
         registerConnectivityFlush()
+
+        // Local push: notify on new cloud inbox messages while this service is alive.
+        inboxNotifier = CloudInboxNotifier(this, serviceScope).also { it.start() }
 
         // Reset retry count on successful service creation
         getSharedPreferences("service_prefs", Context.MODE_PRIVATE)
@@ -77,12 +83,15 @@ class SmsForwarderService : Service() {
         // types!" and tear the service down almost immediately (observed on Android 15).
         startForegroundCompat(createNotification())
 
-        val smsForwardServiceEnabled = intent?.getBooleanExtra("SMS_FORWARD_SERVICE_ENABLED", false) ?: false
-
-        if (smsForwardServiceEnabled) {
-            startListeningForSms()
-        } else {
-            stopSelf()
+        // Read the live prefs (the intent extra is absent on alarm/boot restarts). Keep the
+        // service alive if SMS forwarding OR cloud receive is enabled; stop only if neither is.
+        serviceScope.launch {
+            val prefs = UserPreferences(applicationContext.dataStore)
+            val smsEnabled = prefs.isSmsForwarderService.first()
+            val receiveEnabled = prefs.isReceiveEnabled.first()
+            if (smsEnabled) startListeningForSms() else stopListeningForSms()
+            if (receiveEnabled) inboxNotifier?.start()
+            if (!smsEnabled && !receiveEnabled) stopSelf()
         }
 
         // Schedule a restart if the service gets killed
@@ -188,6 +197,8 @@ class SmsForwarderService : Service() {
         stopListeningForSms()
         networkCallback?.let { cb -> runCatching { connectivityManager?.unregisterNetworkCallback(cb) } }
         networkCallback = null
+        inboxNotifier?.stop()
+        inboxNotifier = null
         serviceScope.cancel()
         Log.d("SmsForwarderService", "Service destroyed.")
     }

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AccessRepository.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/AccessRepository.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeoutOrNull
 
 class AccessRepository(private val db: FirebaseFirestore = FirebaseProvider.db) {
 
@@ -53,15 +54,31 @@ class AccessRepository(private val db: FirebaseFirestore = FirebaseProvider.db) 
         db.collection("devices").document(deviceId).set(mapOf("revoked" to revoked), SetOptions.merge()).await()
     }
 
-    /** Permanently remove a device and ALL of its cloud data (admin-only cleanup). */
+    /**
+     * Permanently remove a device and ALL of its cloud data (admin-only cleanup).
+     * Each cleanup step is best-effort so a single failure (e.g. a collection-group
+     * query that's blocked or unindexed) never prevents the device doc itself from
+     * being deleted.
+     */
     suspend fun removeDeviceAndData(deviceId: String) {
-        deleteQuery(db.collection("inbox").document(deviceId).collection("messages")) // messages it received
-        deleteQuery(db.collectionGroup("messages").whereEqualTo("sourceDeviceId", deviceId)) // messages it sent
+        // Delete the device doc FIRST — it's the essential operation, and it must not be
+        // blocked by data-cleanup steps. (A denied collection-group query doesn't throw
+        // promptly; the SDK retries the listen and the call can hang, so each cleanup is
+        // both best-effort and time-bounded.)
+        runCatching { db.collection("devices").document(deviceId).delete().await() }
+        cleanup { deleteQuery(db.collection("inbox").document(deviceId).collection("messages")) } // received
         for (field in listOf("readerDeviceId", "sourceDeviceId")) {
-            deleteQuery(db.collection("access_matrix").whereEqualTo(field, deviceId))
-            deleteQuery(db.collection("subscriptions").whereEqualTo(field, deviceId))
+            cleanup { deleteQuery(db.collection("access_matrix").whereEqualTo(field, deviceId)) }
+            cleanup { deleteQuery(db.collection("subscriptions").whereEqualTo(field, deviceId)) }
         }
-        db.collection("devices").document(deviceId).delete().await()
+        // Sent messages live in other inboxes; purging them needs the admin collection-group
+        // read rule. Best-effort + bounded so a denial can never hang the removal.
+        cleanup { deleteQuery(db.collectionGroup("messages").whereEqualTo("sourceDeviceId", deviceId)) }
+    }
+
+    /** Best-effort, time-bounded cleanup step — never throws, never hangs the caller. */
+    private suspend fun cleanup(block: suspend () -> Unit) {
+        runCatching { withTimeoutOrNull(8000) { block() } }
     }
 
     private suspend fun deleteQuery(query: Query) {

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/CloudInboxNotifier.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/CloudInboxNotifier.kt
@@ -1,0 +1,123 @@
+package com.viswa2k.smsforwarder.cloud.data
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.viswa2k.smsforwarder.MainActivity
+import com.viswa2k.smsforwarder.R
+import com.viswa2k.smsforwarder.UserPreferences
+import com.viswa2k.smsforwarder.cloud.crypto.CryptoManager
+import com.viswa2k.smsforwarder.dataStore
+import com.google.firebase.firestore.DocumentChange
+import com.google.firebase.firestore.ListenerRegistration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Option 1 push: while the foreground service is alive, listen to this device's cloud inbox
+ * and post a LOCAL notification for each newly-arrived message. No FCM / Cloud Functions /
+ * paid plan required — it just rides on the realtime Firestore listener.
+ *
+ * Behaviour & limits (by design):
+ * - Only runs when signed in AND "Receive cloud messages" is on AND the device is registered.
+ * - The first snapshot is treated as a baseline (existing messages are NOT re-notified).
+ * - Delivers notifications for messages that arrive WHILE the listener is attached. Messages
+ *   that land while the service is dead are surfaced the next time you open Cloud SMS, not as
+ *   a background notification — that gap is exactly what the FCM-based approach (Option 2) closes.
+ */
+class CloudInboxNotifier(context: Context, private val scope: CoroutineScope) {
+    private val appContext = context.applicationContext
+    private val prefs = UserPreferences(appContext.dataStore)
+    private val crypto = CryptoManager(appContext)
+    private val deviceRepo = DeviceRepository(crypto = crypto, prefs = prefs)
+    private val accessRepo = AccessRepository()
+    private val messageRepo = CloudMessageRepository(crypto = crypto, deviceRepo = deviceRepo, accessRepo = accessRepo)
+
+    private var registration: ListenerRegistration? = null
+    private var seenBaseline = false
+    private val notified = HashSet<String>()
+
+    fun start() {
+        if (registration != null) return
+        scope.launch {
+            if (!prefs.isReceiveEnabled.first()) return@launch
+            if (FirebaseProvider.auth.currentUser == null) return@launch
+            val deviceId = prefs.cloudDeviceId.first()
+            if (deviceId.isBlank()) return@launch
+            ensureChannel()
+            registration = FirebaseProvider.db.collection("inbox").document(deviceId)
+                .collection("messages").addSnapshotListener { snap, err ->
+                    if (err != null || snap == null) return@addSnapshotListener
+                    // First callback = baseline of already-stored messages; don't notify those.
+                    if (!seenBaseline) {
+                        snap.documents.forEach { notified.add(it.id) }
+                        seenBaseline = true
+                        return@addSnapshotListener
+                    }
+                    for (change in snap.documentChanges) {
+                        if (change.type != DocumentChange.Type.ADDED) continue
+                        val doc = change.document
+                        if (!notified.add(doc.id)) continue // already handled
+                        val messageId = doc.getString("messageId") ?: doc.id
+                        scope.launch {
+                            runCatching {
+                                val msg = messageRepo.decryptOne(deviceId, messageId, emptyMap()) ?: return@runCatching
+                                postNotification(msg)
+                            }.onFailure { Log.w(TAG, "notify failed", it) }
+                        }
+                    }
+                }
+        }
+    }
+
+    fun stop() {
+        registration?.remove()
+        registration = null
+        seenBaseline = false
+        notified.clear()
+    }
+
+    private fun postNotification(msg: CloudMessageRepository.DecryptedMessage) {
+        val intent = Intent(appContext, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        val pi = PendingIntent.getActivity(
+            appContext, msg.id.hashCode(), intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val title = "Cloud SMS · ${msg.sourceAlias}"
+        val text = if (msg.sender.isNotBlank()) "${msg.sender}: ${msg.body}" else msg.body
+        val n = NotificationCompat.Builder(appContext, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pi)
+            .build()
+        runCatching {
+            NotificationManagerCompat.from(appContext).notify(msg.id.hashCode(), n)
+        }.onFailure { Log.w(TAG, "post failed (notifications disabled?)", it) }
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val ch = NotificationChannel(CHANNEL_ID, "Cloud SMS messages", NotificationManager.IMPORTANCE_HIGH).apply {
+                description = "Alerts when a new message arrives in your cloud inbox"
+            }
+            appContext.getSystemService(NotificationManager::class.java).createNotificationChannel(ch)
+        }
+    }
+
+    companion object {
+        private const val TAG = "CloudInboxNotifier"
+        private const val CHANNEL_ID = "cloud_sms_messages"
+    }
+}

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -44,6 +44,13 @@ service cloud.firestore {
       allow update, delete: if resource != null && ownsDevice(resource.data.readerDeviceId);
     }
 
+    // Admin can read messages across ALL inboxes via collection-group queries
+    // (e.g. purging a device's sent messages). The per-inbox rule below can't be
+    // used for collection-group reads because {deviceId} isn't bound there.
+    match /{path=**}/messages/{messageId} {
+      allow read: if isAdmin();
+    }
+
     match /inbox/{deviceId}/messages/{messageId} {
       allow read: if ownsDevice(deviceId) || isAdmin();
       allow create: if ownsDevice(request.resource.data.sourceDeviceId)


### PR DESCRIPTION
Implements **Option 1**: free local notifications for incoming cloud messages — no FCM, Cloud Functions, or paid plan.

- **CloudInboxNotifier** runs in the foreground service: listens to this device's inbox, posts a local notification (decrypted sender + body preview, tappable) for each new message. Skips the initial baseline so existing messages don't re-notify.
- Service now stays alive when **SMS-forwarding OR cloud-receive** is enabled, so cloud-only users get notifications. `onStartCommand` reads live prefs (robust on alarm/boot restarts).
- Bundled fixes from the device-prune work: `removeDeviceAndData` deletes the device doc first + best-effort/time-bounded cleanup (denied collection-group query can't hang it); rules grant admin collection-group reads on `messages`.

## Verified on-device (AVD + Firebase emulator)
- Service survived the FGS window (dataSync type) and the notifier attached.
- Pushed cloud messages → **4 local notifications** appeared ("Cloud SMS · …" with sender+preview), grouped under the app. Screenshot confirmed.

**Behaviour/limits:** notifications fire while the service is alive (real devices keep it alive via battery-exemption + self-heal). Messages arriving while the app is fully killed surface on next open — that gap is what the optional FCM approach (Option 2) would close.

Note: the rules change needs `firebase deploy --only firestore:rules` to take effect (not done — needs your authorization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)