### PR TITLE
fix(sms): static SMS_RECEIVED receiver (received SMS were being dropped)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,23 @@
             </intent-filter>
         </receiver>
 
+        <!--
+          Static SMS_RECEIVED receiver. Delivered by the OS for every incoming SMS regardless
+          of whether the foreground service is alive, so messages are never missed (the previous
+          runtime-only registration dropped SMS whenever the service wasn't running). Guarded by
+          the system-only BROADCAST_SMS permission. forwardMessage() still respects the master
+          switch + per-channel toggles, so this only forwards when the user has enabled it.
+        -->
+        <receiver
+            android:name=".SmsReceiver"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.BROADCAST_SMS">
+            <intent-filter android:priority="999">
+                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".cloud.fcm.SmsForwarderFcmService"
             android:exported="false">

--- a/app/src/main/java/com/viswa2k/smsforwarder/SMSForwarderService.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/SMSForwarderService.kt
@@ -31,9 +31,9 @@ import kotlinx.coroutines.launch
 
 class SmsForwarderService : Service() {
 
-    private lateinit var smsReceiver: SmsReceiver
-    private var isReceiverRegistered = false // Track receiver registration status
-
+    // SMS reception is handled by the statically-registered SmsReceiver in the manifest, so the
+    // service no longer registers it at runtime (that runtime-only path dropped SMS whenever the
+    // service wasn't alive). This service now only runs the connectivity flush + inbox notifier.
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var connectivityManager: ConnectivityManager? = null
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
@@ -42,7 +42,6 @@ class SmsForwarderService : Service() {
     override fun onCreate() {
         super.onCreate()
         Log.d("SmsForwarderService", "Service created.")
-        smsReceiver = SmsReceiver()
 
         // Flush any queued cloud uploads as soon as the network comes back, instead of
         // waiting for the next app launch / sign-in.
@@ -89,7 +88,6 @@ class SmsForwarderService : Service() {
             val prefs = UserPreferences(applicationContext.dataStore)
             val smsEnabled = prefs.isSmsForwarderService.first()
             val receiveEnabled = prefs.isReceiveEnabled.first()
-            if (smsEnabled) startListeningForSms() else stopListeningForSms()
             if (receiveEnabled) inboxNotifier?.start()
             if (!smsEnabled && !receiveEnabled) stopSelf()
         }
@@ -194,30 +192,12 @@ class SmsForwarderService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
-        stopListeningForSms()
         networkCallback?.let { cb -> runCatching { connectivityManager?.unregisterNetworkCallback(cb) } }
         networkCallback = null
         inboxNotifier?.stop()
         inboxNotifier = null
         serviceScope.cancel()
         Log.d("SmsForwarderService", "Service destroyed.")
-    }
-
-    private fun startListeningForSms() {
-        if (!isReceiverRegistered) {
-            val intentFilter = IntentFilter("android.provider.Telephony.SMS_RECEIVED")
-            ContextCompat.registerReceiver(this, smsReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
-            isReceiverRegistered = true // Update the registration status
-            Log.d("SmsForwarderService", "Started listening for SMS.")
-        }
-    }
-
-    private fun stopListeningForSms() {
-        if (isReceiverRegistered) {
-            unregisterReceiver(smsReceiver)
-            isReceiverRegistered = false // Update the registration status
-            Log.d("SmsForwarderService", "Stopped listening for SMS.")
-        }
     }
 
     private fun createNotification(): Notification {

--- a/app/src/main/java/com/viswa2k/smsforwarder/SMSReceiver.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/SMSReceiver.kt
@@ -94,6 +94,16 @@ class SmsReceiver : BroadcastReceiver() {
     private suspend fun forwardMessage(context: Context, senderNumber: String?, messageBody: String) {
         val prefs: Preferences = context.dataStore.data.first()
 
+        // Master switch: the receiver is always registered (static), but only forward when the
+        // user has turned forwarding on. With the master on, each channel (SMS/Telegram/Cloud)
+        // is gated by its own flag below — so a cloud-only setup just needs Enable Service +
+        // Upload to cloud.
+        val serviceEnabled = prefs[booleanPreferencesKey("SMS_FORWARD_SERVICE")] ?: false
+        if (!serviceEnabled) {
+            Log.d("SmsReceiver", "Forwarding master switch off; ignoring SMS")
+            return
+        }
+
         val isSkipContacts = prefs[booleanPreferencesKey("IS_SKIP_CONTACTS")] ?: false
         if (isSkipContacts && isSenderInContacts(context, senderNumber)) {
             return


### PR DESCRIPTION
## Root cause
`SmsReceiver` was registered **only at runtime** by the foreground service, so an incoming SMS reached the app **only while that service was alive with the receiver registered**. On real devices the `dataSync` FGS gets killed; for cloud-only setups the receiver was often never registered — so the OS dropped the SMS before any processing/upload/Firestore write. Everything downstream was fine; the message never entered the pipeline.

## Fix
- **Static manifest receiver** for `SMS_RECEIVED` (BROADCAST_SMS-guarded, priority 999) — OS delivers every SMS regardless of service state.
- `forwardMessage()` gates on the master switch so static delivery still respects on/off; per-channel logic unchanged.
- Removed runtime registration (avoids double-processing); service keeps connectivity-flush + inbox-notifier.

## Cloud-only setup
Enable Service (master) + Upload to cloud; SMS/Telegram off.

## Verification
- `dumpsys`: SmsReceiver registered for SMS_RECEIVED ✓
- Upload → fan-out → inbox → decrypt → display ✓ (no crash)
- Genymotion can't inject SMS, so the literal delivery step is covered by registration + the unchanged, already-proven onReceive/forward logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)