### PR TITLE
feat(ui): Cloud SMS search/filter + stable per-device id + privacy-once

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/MainActivity.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/MainActivity.kt
@@ -47,8 +47,8 @@ class MainActivity : ComponentActivity() {
         // Initialize DataStore and UserPreferences
         userPreferences = UserPreferences(dataStore)
 
-        // Show privacy policy before anything else
-        showPrivacyPolicy()
+        // Show the privacy policy only until the user acknowledges it once.
+        if (!isPrivacyAccepted()) showPrivacyPolicy()
 
         // Initialize defaults
         lifecycleScope.launch {
@@ -89,15 +89,20 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun isPrivacyAccepted(): Boolean =
+        getSharedPreferences("app_prefs", Context.MODE_PRIVATE).getBoolean("privacy_accepted", false)
+
     private fun showPrivacyPolicy() {
         val builder = AlertDialog.Builder(this)
             .setTitle(getString(R.string.privacy_policy_title))
             .setMessage(getString(R.string.privacy_policy_summary))
             .setPositiveButton("I Understand") { dialog, _ ->
+                getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+                    .edit().putBoolean("privacy_accepted", true).apply()
                 dialog.dismiss()
             }
             .setCancelable(false)
-        
+
         builder.show()
     }
 

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/CloudInboxNotifier.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/CloudInboxNotifier.kt
@@ -36,7 +36,7 @@ class CloudInboxNotifier(context: Context, private val scope: CoroutineScope) {
     private val appContext = context.applicationContext
     private val prefs = UserPreferences(appContext.dataStore)
     private val crypto = CryptoManager(appContext)
-    private val deviceRepo = DeviceRepository(crypto = crypto, prefs = prefs)
+    private val deviceRepo = DeviceRepository(context = appContext, crypto = crypto, prefs = prefs)
     private val accessRepo = AccessRepository()
     private val messageRepo = CloudMessageRepository(crypto = crypto, deviceRepo = deviceRepo, accessRepo = accessRepo)
 

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/DeviceRepository.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/DeviceRepository.kt
@@ -1,5 +1,8 @@
 package com.viswa2k.smsforwarder.cloud.data
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.provider.Settings
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import com.viswa2k.smsforwarder.UserPreferences
@@ -10,14 +13,18 @@ import java.util.Base64
 import java.util.UUID
 
 class DeviceRepository(
-    private val db: FirebaseFirestore = FirebaseProvider.db,
+    private val context: Context,
     private val crypto: CryptoManager,
     private val prefs: UserPreferences,
+    private val db: FirebaseFirestore = FirebaseProvider.db,
 ) {
     suspend fun registerThisDevice(ownerEmail: String, alias: String): String {
         crypto.ensureIdentityKey()
-        var id = prefs.cloudDeviceId.first()
-        if (id.isBlank()) { id = UUID.randomUUID().toString(); prefs.saveCloudDeviceId(id) }
+        // Stable per-physical-device id (survives reinstall/login), so one device = one entry
+        // instead of a fresh random UUID on every install.
+        val existing = prefs.cloudDeviceId.first()
+        val id = stableDeviceId() ?: existing.ifBlank { UUID.randomUUID().toString() }
+        if (existing != id) prefs.saveCloudDeviceId(id)
         val pub = Base64.getEncoder().encodeToString(crypto.publicKeyset())
         db.collection("devices").document(id).set(
             mapOf(
@@ -29,6 +36,18 @@ class DeviceRepository(
             SetOptions.merge(),
         ).await()
         return id
+    }
+
+    /**
+     * A stable identifier for this physical device + app install signing key. Unlike a random
+     * UUID it survives uninstall/reinstall and re-login, so the same device maps to one doc.
+     * Returns null on the rare devices where ANDROID_ID is missing/the known-buggy value, so the
+     * caller can fall back to a persisted UUID.
+     */
+    @SuppressLint("HardwareIds")
+    private fun stableDeviceId(): String? {
+        val aid = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+        return if (!aid.isNullOrBlank() && aid != "9774d56d682e549c") "android-$aid" else null
     }
 
     suspend fun updateFcmToken(token: String) {

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/SmsCloudUploader.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/SmsCloudUploader.kt
@@ -14,7 +14,7 @@ class SmsCloudUploader private constructor(context: Context) {
     private val appContext = context.applicationContext
     private val prefs = UserPreferences(appContext.dataStore)
     private val crypto = CryptoManager(appContext)
-    private val deviceRepo = DeviceRepository(crypto = crypto, prefs = prefs)
+    private val deviceRepo = DeviceRepository(context = appContext, crypto = crypto, prefs = prefs)
     private val accessRepo = AccessRepository()
     private val messageRepo = CloudMessageRepository(crypto = crypto, deviceRepo = deviceRepo, accessRepo = accessRepo)
     private val queue = CloudUploadQueue(File(appContext.filesDir, "cloud_upload_queue"))

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/fcm/SmsForwarderFcmService.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/fcm/SmsForwarderFcmService.kt
@@ -24,7 +24,7 @@ class SmsForwarderFcmService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         val prefs = UserPreferences(applicationContext.dataStore)
-        val deviceRepo = DeviceRepository(crypto = CryptoManager(applicationContext), prefs = prefs)
+        val deviceRepo = DeviceRepository(context = applicationContext, crypto = CryptoManager(applicationContext), prefs = prefs)
         CoroutineScope(Dispatchers.IO).launch { runCatching { deviceRepo.updateFcmToken(token) } }
     }
 
@@ -39,7 +39,7 @@ class SmsForwarderFcmService : FirebaseMessagingService() {
             val readerDeviceId = prefs.cloudDeviceId.first()
             if (readerDeviceId.isBlank()) return@launch
             val crypto = CryptoManager(ctx)
-            val deviceRepo = DeviceRepository(crypto = crypto, prefs = prefs)
+            val deviceRepo = DeviceRepository(context = ctx, crypto = crypto, prefs = prefs)
             val messageRepo = CloudMessageRepository(crypto = crypto, deviceRepo = deviceRepo, accessRepo = AccessRepository())
             val aliases = runCatching { deviceRepo.fetchFleetDevices().associate { it.id to it.alias } }.getOrDefault(emptyMap())
             val decrypted = runCatching { messageRepo.decryptOne(readerDeviceId, messageId, aliases) }.getOrNull() ?: return@launch

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/AdminScreen.kt
@@ -13,9 +13,12 @@ import com.viswa2k.smsforwarder.cloud.data.AuthorizedEmail
 import com.viswa2k.smsforwarder.cloud.data.Device
 import kotlinx.coroutines.launch
 
+/** Short, meaningful slice of a device id (strips the stable "android-" prefix for display). */
+private fun shortId(id: String): String = id.removePrefix("android-").take(8)
+
 /** Disambiguates same-named devices with a short id, and tags the current device. */
 private fun chipLabel(d: Device, myDeviceId: String): String =
-    d.alias.ifBlank { "(unnamed)" } + " ·" + d.id.take(4) + if (d.id == myDeviceId) " ★" else ""
+    d.alias.ifBlank { "(unnamed)" } + " ·" + shortId(d.id).take(4) + if (d.id == myDeviceId) " ★" else ""
 
 /** Turns raw Firestore/SDK exceptions into a short, human-friendly message (no "PERMISSION_DENIED"). */
 private fun friendlyError(t: Throwable): String {
@@ -166,7 +169,7 @@ fun AdminScreen(vm: CloudViewModel, onBack: () -> Unit) {
                             },
                             style = MaterialTheme.typography.bodyLarge,
                         )
-                        Text("id ${d.id.take(8)}  ·  ${d.ownerEmail}", style = MaterialTheme.typography.bodySmall)
+                        Text("id ${shortId(d.id)}  ·  ${d.ownerEmail}", style = MaterialTheme.typography.bodySmall)
                     }
                     TextButton(onClick = { act { access.setDeviceRevoked(d.id, !d.revoked) } }) { Text(if (d.revoked) "Un-revoke" else "Revoke") }
                     if (!isThis) {

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudSmsScreen.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudSmsScreen.kt
@@ -2,12 +2,15 @@ package com.viswa2k.smsforwarder.cloud.ui
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -17,6 +20,9 @@ fun CloudSmsScreen(vm: CloudViewModel, onOpenWatch: () -> Unit, onOpenAdmin: () 
     val isAdmin by vm.isAdmin.collectAsState()
     var menuOpen by remember { mutableStateOf(false) }
     var showPasswordDialog by remember { mutableStateOf(false) }
+    var query by remember { mutableStateOf("") }
+    var deviceFilter by remember { mutableStateOf<String?>(null) }
+    val listState = rememberLazyListState()
 
     LaunchedEffect(Unit) { vm.refreshMessages(); vm.startRealtime() }
     DisposableEffect(Unit) { onDispose { vm.stopRealtime() } }
@@ -53,39 +59,101 @@ fun CloudSmsScreen(vm: CloudViewModel, onOpenWatch: () -> Unit, onOpenAdmin: () 
             )
         },
     ) { padding ->
-        if (messages.isEmpty()) {
-            Column(
-                Modifier.fillMaxSize().padding(padding).padding(32.dp),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text("No cloud messages yet", style = MaterialTheme.typography.titleMedium)
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    "Cloud SMS shows incoming texts from your other devices, end-to-end encrypted. " +
+        Column(Modifier.fillMaxSize().padding(padding)) {
+            if (messages.isEmpty()) {
+                EmptyState("No cloud messages yet",
+                    "Cloud SMS shows incoming texts from your devices, end-to-end encrypted. " +
                         "Enable \"Upload to cloud\" on a device to send its SMS here, and use Watch to follow " +
-                        "the devices you're allowed to read.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-                )
+                        "the devices you're allowed to read.")
+                return@Column
             }
-        } else {
-            LazyColumn(Modifier.fillMaxSize().padding(padding).padding(horizontal = 12.dp)) {
-                items(messages, key = { it.id }) { m ->
-                    ElevatedCard(Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
-                        Column(Modifier.padding(12.dp)) {
-                            Text("${m.sourceAlias} • ${m.sender}", style = MaterialTheme.typography.labelMedium)
-                            Spacer(Modifier.height(4.dp))
-                            Text(m.body, style = MaterialTheme.typography.bodyLarge)
-                            if (isAdmin) {
-                                Spacer(Modifier.height(4.dp))
-                                TextButton(onClick = { vm.deleteMessage(m.id) }) { Text("Delete") }
+
+            // Search across sender / body / device alias.
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                singleLine = true,
+                label = { Text("Search messages, sender or device") },
+                trailingIcon = {
+                    if (query.isNotEmpty()) TextButton(onClick = { query = "" }) { Text("Clear") }
+                },
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+            )
+
+            // Filter by source device.
+            val devices = remember(messages) { messages.map { it.sourceAlias }.filter { it.isNotBlank() }.distinct().sorted() }
+            if (devices.size > 1) {
+                LazyRow(
+                    Modifier.fillMaxWidth().padding(horizontal = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    item {
+                        FilterChip(selected = deviceFilter == null, onClick = { deviceFilter = null }, label = { Text("All") })
+                    }
+                    items(devices, key = { it }) { d ->
+                        FilterChip(
+                            selected = deviceFilter == d,
+                            onClick = { deviceFilter = if (deviceFilter == d) null else d },
+                            label = { Text(d) },
+                        )
+                    }
+                }
+            }
+
+            val filtered = remember(messages, query, deviceFilter) {
+                messages.filter { m ->
+                    (deviceFilter == null || m.sourceAlias == deviceFilter) &&
+                        (query.isBlank() ||
+                            m.body.contains(query, ignoreCase = true) ||
+                            m.sender.contains(query, ignoreCase = true) ||
+                            m.sourceAlias.contains(query, ignoreCase = true))
+                }
+            }
+
+            if (filtered.isEmpty()) {
+                EmptyState("No matches", "No messages match your search/filter. Try clearing them.")
+            } else {
+                LazyColumn(
+                    Modifier.fillMaxSize().padding(horizontal = 12.dp),
+                    state = listState,
+                    contentPadding = PaddingValues(vertical = 6.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(filtered, key = { it.id }) { m ->
+                        ElevatedCard(Modifier.fillMaxWidth()) {
+                            Column(Modifier.padding(14.dp)) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(m.sourceAlias.ifBlank { "Unknown device" },
+                                        style = MaterialTheme.typography.titleSmall, modifier = Modifier.weight(1f))
+                                    Text(m.sender, style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                }
+                                Spacer(Modifier.height(6.dp))
+                                Text(m.body, style = MaterialTheme.typography.bodyLarge)
+                                if (isAdmin) {
+                                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                                        TextButton(onClick = { vm.deleteMessage(m.id) }) { Text("Delete") }
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ColumnScope.EmptyState(title: String, body: String) {
+    Column(
+        Modifier.fillMaxWidth().weight(1f).padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(title, style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(8.dp))
+        Text(body, style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
     }
 }
 

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/ui/CloudViewModel.kt
@@ -25,7 +25,7 @@ class CloudViewModel(app: Application) : AndroidViewModel(app) {
     private val prefs = UserPreferences(app.dataStore)
     private val crypto = CryptoManager(app)
     private val auth = AuthRepository()
-    private val deviceRepo = DeviceRepository(crypto = crypto, prefs = prefs)
+    private val deviceRepo = DeviceRepository(context = app, crypto = crypto, prefs = prefs)
     private val accessRepo = AccessRepository()
     private val messageRepo = CloudMessageRepository(crypto = crypto, deviceRepo = deviceRepo, accessRepo = accessRepo)
 


### PR DESCRIPTION
Three fixes:

1. **Cloud SMS list revamp** — search (sender/body/device), device filter chips (when >1 device), modern cards, smoother spacing/scroll. Verified: search narrows correctly + 'No matches' state.
2. **Stable per-device id** — root cause of duplicate device entries: id was a random UUID stored in DataStore, so every reinstall (DataStore wipe) minted a new device. Now derived from `ANDROID_ID` → survives reinstall/login, one physical device = one entry. Falls back to UUID only if ANDROID_ID unavailable. Verified id = `android-<ANDROID_ID>`.
3. **Privacy dialog shows once** — was shown unconditionally every launch; now gated by an acknowledged flag. Verified it doesn't reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)