### PR TITLE
fix(device): keep existing device id (no orphaned inbox) + debug test-SMS

### DIFF
--- a/app/src/main/java/com/viswa2k/smsforwarder/MainActivity.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/MainActivity.kt
@@ -61,6 +61,17 @@ class MainActivity : ComponentActivity() {
             } catch (e: Exception) { Log.e("MainActivity", "queue flush failed", e) }
         }
 
+        // Debug-only: a dynamic, exported receiver for the test-SMS action so `adb broadcast`
+        // can exercise the real SmsReceiver→forward→upload path (emulator SMS injection is
+        // license-blocked). Never registered in release builds.
+        if (BuildConfig.DEBUG) {
+            ContextCompat.registerReceiver(
+                this, SmsReceiver(),
+                android.content.IntentFilter(SmsReceiver.TEST_ACTION),
+                ContextCompat.RECEIVER_EXPORTED,
+            )
+        }
+
         // Check for battery optimization exemption
         checkBatteryOptimization()
 

--- a/app/src/main/java/com/viswa2k/smsforwarder/SMSReceiver.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/SMSReceiver.kt
@@ -29,23 +29,33 @@ class SmsReceiver : BroadcastReceiver() {
     var globalMessageFormat = ""
     var deviceAlias = ""
 
+    companion object {
+        const val TEST_ACTION = "com.viswa2k.smsforwarder.TEST_SMS_RECEIVED"
+    }
+
     override fun onReceive(context: Context, intent: Intent) {
         val pendingResult = goAsync()
         Log.d("Message Receiver", "Received message")
 
-        // Parse PDUs synchronously (fast, no I/O) before handing off to a background coroutine.
         val messages = mutableListOf<Pair<String?, String>>()
-        try {
-            val bundle: Bundle? = intent.extras
-            if (bundle != null) {
-                val pdus = bundle.get("pdus") as Array<*>
-                for (pdu in pdus) {
-                    val smsMessage = SmsMessage.createFromPdu(pdu as ByteArray)
-                    messages.add(smsMessage.displayOriginatingAddress to smsMessage.messageBody)
+        if (BuildConfig.DEBUG && intent.action == TEST_ACTION) {
+            // Debug-only: simulate an incoming SMS without the telephony stack (the emulator's
+            // free license blocks SMS injection). Exercises the exact forward/upload path.
+            messages.add((intent.getStringExtra("sender") ?: "TEST") to (intent.getStringExtra("body") ?: ""))
+        } else {
+            // Parse PDUs synchronously (fast, no I/O) before handing off to a background coroutine.
+            try {
+                val bundle: Bundle? = intent.extras
+                if (bundle != null) {
+                    val pdus = bundle.get("pdus") as Array<*>
+                    for (pdu in pdus) {
+                        val smsMessage = SmsMessage.createFromPdu(pdu as ByteArray)
+                        messages.add(smsMessage.displayOriginatingAddress to smsMessage.messageBody)
+                    }
                 }
+            } catch (e: Exception) {
+                Log.e("SmsReceiver", "Error parsing SMS")
             }
-        } catch (e: Exception) {
-            Log.e("SmsReceiver", "Error parsing SMS")
         }
 
         // Forward off the main thread; goAsync() keeps the process alive until finish().

--- a/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/DeviceRepository.kt
+++ b/app/src/main/java/com/viswa2k/smsforwarder/cloud/data/DeviceRepository.kt
@@ -20,10 +20,12 @@ class DeviceRepository(
 ) {
     suspend fun registerThisDevice(ownerEmail: String, alias: String): String {
         crypto.ensureIdentityKey()
-        // Stable per-physical-device id (survives reinstall/login), so one device = one entry
-        // instead of a fresh random UUID on every install.
+        // Keep an already-assigned id (so existing installs don't lose their inbox/messages),
+        // and only mint one when none exists. For fresh installs/reinstalls we derive it from
+        // ANDROID_ID so the SAME physical device reuses ONE entry across reinstalls instead of
+        // piling up a new random UUID each time.
         val existing = prefs.cloudDeviceId.first()
-        val id = stableDeviceId() ?: existing.ifBlank { UUID.randomUUID().toString() }
+        val id = existing.ifBlank { stableDeviceId() ?: UUID.randomUUID().toString() }
         if (existing != id) prefs.saveCloudDeviceId(id)
         val pub = Base64.getEncoder().encodeToString(crypto.publicKeyset())
         db.collection("devices").document(id).set(


### PR DESCRIPTION
**Fixes the 'messages disappeared after update' regression from v1.2.2.** That build preferred a fresh ANDROID_ID over the stored id, changing the id on existing installs and orphaning their inbox. Now: keep the existing id; use ANDROID_ID only when none exists (fresh install/reinstall). One device = one entry, dedupes across reinstall, no orphaning for current users.

Also adds a **debug-only** test-SMS broadcast (`TEST_SMS_RECEIVED`) — exercises the full receive→forward→upload→display path where emulator SMS injection is license-blocked. Release builds never register it.

**Verified end-to-end on AVD:** broadcasting a test SMS produced a Cloud SMS entry (sender + body) through the real static-receiver pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)